### PR TITLE
change fond-of-oryx/erp-order version, because at the moment there is…

### DIFF
--- a/bundles/erp-order-api/composer.json
+++ b/bundles/erp-order-api/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "php": ">=7.3",
-    "fond-of-oryx/erp-order": "^1.0.0",
+    "fond-of-oryx/erp-order": "dev-main",
     "spryker/api": "^0.1.0 || ^0.2.0 || ^0.3.0",
     "spryker/api-query-builder": "^0.1.0"
   },


### PR DESCRIPTION
… no stable version