### PR TITLE
Add persistence performance fix and new facade method 💨

### DIFF
--- a/bundles/product-locale-restriction/src/FondOfOryx/Zed/ProductLocaleRestriction/Business/ProductLocaleRestrictionFacade.php
+++ b/bundles/product-locale-restriction/src/FondOfOryx/Zed/ProductLocaleRestriction/Business/ProductLocaleRestrictionFacade.php
@@ -40,4 +40,20 @@ class ProductLocaleRestrictionFacade extends AbstractFacade implements ProductLo
     {
         return $this->getFactory()->createProductAbstractExpander()->expand($productAbstractTransfer);
     }
+
+    /**
+     * Specifications:
+     * - Retrieves blacklisted locale ids for product abstract ids.
+     * - Returns blacklisted locales (key: product abstract id, value: array of locale ids).
+     *
+     * @api
+     *
+     * @param int[] $productAbstractIds
+     *
+     * @return array
+     */
+    public function getBlacklistedLocaleIdsByProductAbstractIds(array $productAbstractIds): array
+    {
+        return $this->getRepository()->findBlacklistedLocaleIdsByProductAbstractIds($productAbstractIds);
+    }
 }

--- a/bundles/product-locale-restriction/src/FondOfOryx/Zed/ProductLocaleRestriction/Business/ProductLocaleRestrictionFacadeInterface.php
+++ b/bundles/product-locale-restriction/src/FondOfOryx/Zed/ProductLocaleRestriction/Business/ProductLocaleRestrictionFacadeInterface.php
@@ -29,4 +29,17 @@ interface ProductLocaleRestrictionFacadeInterface
      * @return \Generated\Shared\Transfer\ProductAbstractTransfer
      */
     public function expandProductAbstract(ProductAbstractTransfer $productAbstractTransfer): ProductAbstractTransfer;
+
+    /**
+     * Specifications:
+     * - Retrieves blacklisted locale ids for product abstract ids.
+     * - Returns blacklisted locales (key: product abstract id, value: array of locale ids).
+     *
+     * @api
+     *
+     * @param int[] $productAbstractIds
+     *
+     * @return array
+     */
+    public function getBlacklistedLocaleIdsByProductAbstractIds(array $productAbstractIds): array;
 }

--- a/bundles/product-locale-restriction/src/FondOfOryx/Zed/ProductLocaleRestriction/Persistence/ProductLocaleRestrictionRepository.php
+++ b/bundles/product-locale-restriction/src/FondOfOryx/Zed/ProductLocaleRestriction/Persistence/ProductLocaleRestrictionRepository.php
@@ -22,6 +22,7 @@ class ProductLocaleRestrictionRepository extends AbstractRepository implements P
 
         $fooProductAbstractLocaleRestrictionCollection = $fooProductAbstractLocaleRestrictionQuery
             ->filterByFkProductAbstract($idProductAbstract)
+            ->innerJoinWithLocale()
             ->find();
 
         return $this->getFactory()->createProductAbstractLocaleRestrictionMapper()
@@ -42,5 +43,23 @@ class ProductLocaleRestrictionRepository extends AbstractRepository implements P
             ->select(FooProductAbstractLocaleRestrictionTableMap::COL_FK_LOCALE)
             ->findByFkProductAbstract($idProductAbstract)
             ->toArray();
+    }
+
+    /**
+     * @param int[] $idProductAbstracts
+     *
+     * @return array
+     */
+    public function findBlacklistedLocaleIdsByProductAbstractIds(array $idProductAbstracts): array
+    {
+        $fooProductAbstractLocaleRestrictionQuery = $this->getFactory()
+            ->createFooProductAbstractLocaleRestrictionQuery();
+
+        $fooProductAbstractLocaleRestrictionCollection = $fooProductAbstractLocaleRestrictionQuery
+            ->filterByFkProductAbstract_In($idProductAbstracts)
+            ->find();
+
+        return $this->getFactory()->createProductAbstractLocaleRestrictionMapper()
+            ->mapEntityCollectionToGroupedLocaleIds($fooProductAbstractLocaleRestrictionCollection);
     }
 }

--- a/bundles/product-locale-restriction/src/FondOfOryx/Zed/ProductLocaleRestriction/Persistence/ProductLocaleRestrictionRepositoryInterface.php
+++ b/bundles/product-locale-restriction/src/FondOfOryx/Zed/ProductLocaleRestriction/Persistence/ProductLocaleRestrictionRepositoryInterface.php
@@ -21,4 +21,13 @@ interface ProductLocaleRestrictionRepositoryInterface
     public function findLocaleBlacklistIdsByIdProductAbstract(
         int $idProductAbstract
     ): array;
+
+    /**
+     * @param int[] $idProductAbstracts
+     *
+     * @return array
+     */
+    public function findBlacklistedLocaleIdsByProductAbstractIds(
+        array $idProductAbstracts
+    ): array;
 }

--- a/bundles/product-locale-restriction/src/FondOfOryx/Zed/ProductLocaleRestriction/Persistence/Propel/Mapper/ProductAbstractLocaleRestrictionMapper.php
+++ b/bundles/product-locale-restriction/src/FondOfOryx/Zed/ProductLocaleRestriction/Persistence/Propel/Mapper/ProductAbstractLocaleRestrictionMapper.php
@@ -28,6 +28,30 @@ class ProductAbstractLocaleRestrictionMapper implements ProductAbstractLocaleRes
     }
 
     /**
+     * @param \Propel\Runtime\Collection\ObjectCollection|\Orm\Zed\ProductLocaleRestriction\Persistence\FooProductAbstractLocaleRestriction[] $fooProductAbstractLocaleRestrictionCollection
+     *
+     * @return array
+     */
+    public function mapEntityCollectionToGroupedLocaleIds(
+        ObjectCollection $fooProductAbstractLocaleRestrictionCollection
+    ): array {
+        $groupedLocaleIds = [];
+
+        foreach ($fooProductAbstractLocaleRestrictionCollection as $fooProductAbstractLocaleRestriction) {
+            $idProductAbstract = $fooProductAbstractLocaleRestriction->getFkProductAbstract();
+            $idLocale = $fooProductAbstractLocaleRestriction->getFkLocale();
+
+            if (!isset($groupedLocaleIds[$idProductAbstract])) {
+                $groupedLocaleIds[$idProductAbstract] = [];
+            }
+
+            $groupedLocaleIds[$idProductAbstract][] = $idLocale;
+        }
+
+        return $groupedLocaleIds;
+    }
+
+    /**
      * @param \Generated\Shared\Transfer\ProductAbstractLocaleRestrictionTransfer $transfer
      * @param \Orm\Zed\ProductLocaleRestriction\Persistence\FooProductAbstractLocaleRestriction $entity
      *

--- a/bundles/product-locale-restriction/src/FondOfOryx/Zed/ProductLocaleRestriction/Persistence/Propel/Mapper/ProductAbstractLocaleRestrictionMapperInterface.php
+++ b/bundles/product-locale-restriction/src/FondOfOryx/Zed/ProductLocaleRestriction/Persistence/Propel/Mapper/ProductAbstractLocaleRestrictionMapperInterface.php
@@ -27,4 +27,13 @@ interface ProductAbstractLocaleRestrictionMapperInterface
         ProductAbstractLocaleRestrictionTransfer $transfer,
         FooProductAbstractLocaleRestriction $entity
     ): FooProductAbstractLocaleRestriction;
+
+    /**
+     * @param \Propel\Runtime\Collection\ObjectCollection|\Orm\Zed\ProductLocaleRestriction\Persistence\FooProductAbstractLocaleRestriction[] $fooProductAbstractLocaleRestrictionCollection
+     *
+     * @return array
+     */
+    public function mapEntityCollectionToGroupedLocaleIds(
+        ObjectCollection $fooProductAbstractLocaleRestrictionCollection
+    ): array;
 }

--- a/bundles/product-locale-restriction/tests/FondOfOryx/Zed/ProductLocaleRestriction/Business/ProductLocaleRestrictionFacadeTest.php
+++ b/bundles/product-locale-restriction/tests/FondOfOryx/Zed/ProductLocaleRestriction/Business/ProductLocaleRestrictionFacadeTest.php
@@ -5,6 +5,7 @@ namespace FondOfOryx\Zed\ProductLocaleRestriction\Business;
 use Codeception\Test\Unit;
 use FondOfOryx\Zed\ProductLocaleRestriction\Business\Model\ProductAbstractExpanderInterface;
 use FondOfOryx\Zed\ProductLocaleRestriction\Business\Model\ProductAbstractLocaleRestrictionsPersisterInterface;
+use FondOfOryx\Zed\ProductLocaleRestriction\Persistence\ProductLocaleRestrictionRepository;
 use Generated\Shared\Transfer\ProductAbstractTransfer;
 
 class ProductLocaleRestrictionFacadeTest extends Unit
@@ -13,6 +14,11 @@ class ProductLocaleRestrictionFacadeTest extends Unit
      * @var \FondOfOryx\Zed\ProductLocaleRestriction\Business\ProductLocaleRestrictionBusinessFactory|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $factoryMock;
+
+    /**
+     * @var \FondOfOryx\Zed\ProductLocaleRestriction\Persistence\ProductLocaleRestrictionRepository|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $repositoryMock;
 
     /**
      * @var \FondOfOryx\Zed\ProductLocaleRestriction\Business\Model\ProductAbstractExpanderInterface|\PHPUnit\Framework\MockObject\MockObject
@@ -45,6 +51,10 @@ class ProductLocaleRestrictionFacadeTest extends Unit
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->repositoryMock = $this->getMockBuilder(ProductLocaleRestrictionRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $this->productAbstractExpanderMock = $this->getMockBuilder(ProductAbstractExpanderInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -59,6 +69,7 @@ class ProductLocaleRestrictionFacadeTest extends Unit
 
         $this->productLocaleRestrictionFacade = new ProductLocaleRestrictionFacade();
         $this->productLocaleRestrictionFacade->setFactory($this->factoryMock);
+        $this->productLocaleRestrictionFacade->setRepository($this->repositoryMock);
     }
 
     /**
@@ -96,6 +107,27 @@ class ProductLocaleRestrictionFacadeTest extends Unit
 
         $this->productLocaleRestrictionFacade->persistProductAbstractLocaleRestrictions(
             $this->productAbstractTransferMock
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetBlacklistedLocaleIdsByProductAbstractIds(): void
+    {
+        $productAbstractIds = [1, 2];
+        $blacklistedLocaleIds = [2, 4];
+
+        $this->repositoryMock->expects(static::atLeastOnce())
+            ->method('findBlacklistedLocaleIdsByProductAbstractIds')
+            ->with($productAbstractIds)
+            ->willReturn($blacklistedLocaleIds);
+
+        static::assertEquals(
+            $blacklistedLocaleIds,
+            $this->productLocaleRestrictionFacade->getBlacklistedLocaleIdsByProductAbstractIds(
+                $productAbstractIds
+            )
         );
     }
 }


### PR DESCRIPTION
- get locales in bulk (use one inner join instead of multiple selects)
- Add facade method to get an hash map (key: idProductAbstract, value: [idLocale1, ..., idLocaleN]) by productAbstractIds
- ...