### PR TITLE
Make unit tests backwards compatible

### DIFF
--- a/bundles/customer-statistic/tests/FondOfOryx/Zed/CustomerStatistic/Communication/Controller/GatewayControllerTest.php
+++ b/bundles/customer-statistic/tests/FondOfOryx/Zed/CustomerStatistic/Communication/Controller/GatewayControllerTest.php
@@ -49,28 +49,33 @@ class GatewayControllerTest extends Unit
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->gatewayController = new class ($this->customerStatisticFacadeMock) extends GatewayController {
-            /**
-             * @var \FondOfOryx\Zed\CustomerStatistic\Business\CustomerStatisticFacade
-             */
-            protected $customerStatisticFacade;
+        if (method_exists(GatewayController::class, 'setFacade')) {
+            $this->gatewayController = new GatewayController();
+            $this->gatewayController->setFacade($this->customerStatisticFacadeMock);
+        } else {
+            $this->gatewayController = new class ($this->customerStatisticFacadeMock) extends GatewayController {
+                /**
+                 * @var \FondOfOryx\Zed\CustomerStatistic\Business\CustomerStatisticFacade
+                 */
+                protected $customerStatisticFacade;
 
-            /**
-             * @param \FondOfOryx\Zed\CustomerStatistic\Business\CustomerStatisticFacade $customerStatisticFacade
-             */
-            public function __construct(CustomerStatisticFacade $customerStatisticFacade)
-            {
-                $this->customerStatisticFacade = $customerStatisticFacade;
-            }
+                /**
+                 * @param \FondOfOryx\Zed\CustomerStatistic\Business\CustomerStatisticFacade $customerStatisticFacade
+                 */
+                public function __construct(CustomerStatisticFacade $customerStatisticFacade)
+                {
+                    $this->customerStatisticFacade = $customerStatisticFacade;
+                }
 
-            /**
-             * @return \Spryker\Zed\Kernel\Business\AbstractFacade
-             */
-            public function getFacade(): AbstractFacade
-            {
-                return $this->customerStatisticFacade;
-            }
-        };
+                /**
+                 * @return \Spryker\Zed\Kernel\Business\AbstractFacade
+                 */
+                protected function getFacade(): AbstractFacade
+                {
+                    return $this->customerStatisticFacade;
+                }
+            };
+        }
     }
 
     /**

--- a/bundles/product-country-restriction-checkout-connector/tests/FondOfOryx/Client/ProductCountryRestrictionCheckoutConnector/Plugin/CheckoutExtension/ProductCountryRestrictionCheckoutPreCheckPluginTest.php
+++ b/bundles/product-country-restriction-checkout-connector/tests/FondOfOryx/Client/ProductCountryRestrictionCheckoutConnector/Plugin/CheckoutExtension/ProductCountryRestrictionCheckoutPreCheckPluginTest.php
@@ -6,6 +6,7 @@ use Codeception\Test\Unit;
 use FondOfOryx\Client\ProductCountryRestrictionCheckoutConnector\ProductCountryRestrictionCheckoutConnectorClient;
 use Generated\Shared\Transfer\QuoteTransfer;
 use Generated\Shared\Transfer\QuoteValidationResponseTransfer;
+use Spryker\Client\Kernel\AbstractClient;
 
 class ProductCountryRestrictionCheckoutPreCheckPluginTest extends Unit
 {
@@ -48,8 +49,33 @@ class ProductCountryRestrictionCheckoutPreCheckPluginTest extends Unit
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->productCountryRestrictionCheckoutPreCheckPlugin = new ProductCountryRestrictionCheckoutPreCheckPlugin();
-        $this->productCountryRestrictionCheckoutPreCheckPlugin->setClient($this->clientMock);
+        if (method_exists(ProductCountryRestrictionCheckoutPreCheckPlugin::class, 'setClient')) {
+            $this->productCountryRestrictionCheckoutPreCheckPlugin = new ProductCountryRestrictionCheckoutPreCheckPlugin();
+            $this->productCountryRestrictionCheckoutPreCheckPlugin->setClient($this->clientMock);
+        } else {
+            $this->productCountryRestrictionCheckoutPreCheckPlugin = new class ($this->clientMock) extends ProductCountryRestrictionCheckoutPreCheckPlugin {
+                /**
+                 * @var \Spryker\Client\Kernel\AbstractClient
+                 */
+                protected $productCountryRestrictionCheckoutConnectorClient;
+
+                /**
+                 * @param \Spryker\Client\Kernel\AbstractClient $client
+                 */
+                public function __construct(AbstractClient $client)
+                {
+                    $this->productCountryRestrictionCheckoutConnectorClient = $client;
+                }
+
+                /**
+                 * @return \Spryker\Client\Kernel\AbstractClient
+                 */
+                protected function getClient(): AbstractClient
+                {
+                    return $this->productCountryRestrictionCheckoutConnectorClient;
+                }
+            };
+        }
     }
 
     /**

--- a/bundles/product-country-restriction-checkout-connector/tests/FondOfOryx/Zed/ProductCountryRestrictionCheckoutConnector/Communication/Controller/GatewayControllerTest.php
+++ b/bundles/product-country-restriction-checkout-connector/tests/FondOfOryx/Zed/ProductCountryRestrictionCheckoutConnector/Communication/Controller/GatewayControllerTest.php
@@ -49,15 +49,33 @@ class GatewayControllerTest extends Unit
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->gatewayController = new class ($this->facadeMock) extends GatewayController {
-            /**
-             * @param \Spryker\Zed\Kernel\Business\AbstractFacade $facade
-             */
-            public function __construct(AbstractFacade $facade)
-            {
-                $this->facade = $facade;
-            }
-        };
+        if (method_exists(GatewayController::class, 'setFacade')) {
+            $this->gatewayController = new GatewayController();
+            $this->gatewayController->setFacade($this->facadeMock);
+        } else {
+            $this->gatewayController = new class ($this->facadeMock) extends GatewayController {
+                /**
+                 * @var \Spryker\Zed\Kernel\Business\AbstractFacade
+                 */
+                protected $productCountryRestrictionCheckoutConnectorFacade;
+
+                /**
+                 * @param \Spryker\Zed\Kernel\Business\AbstractFacade $facade
+                 */
+                public function __construct(AbstractFacade $facade)
+                {
+                    $this->productCountryRestrictionCheckoutConnectorFacade = $facade;
+                }
+
+                /**
+                 * @return \Spryker\Zed\Kernel\Business\AbstractFacade
+                 */
+                protected function getFacade(): AbstractFacade
+                {
+                    return $this->productCountryRestrictionCheckoutConnectorFacade;
+                }
+            };
+        }
     }
 
     /**

--- a/bundles/product-locale-restriction-cart-connector/tests/FondOfOryx/Zed/ProductLocaleRestrictionCartConnector/Business/Model/CartCheckerTest.php
+++ b/bundles/product-locale-restriction-cart-connector/tests/FondOfOryx/Zed/ProductLocaleRestrictionCartConnector/Business/Model/CartCheckerTest.php
@@ -2,11 +2,11 @@
 
 namespace FondOfOryx\Zed\ProductLocaleRestrictionCartConnector\Business\Model;
 
+use ArrayObject;
 use Codeception\Test\Unit;
 use FondOfOryx\Zed\ProductLocaleRestrictionCartConnector\Dependency\Facade\ProductLocaleRestrictionCartConnectorToProductLocaleRestrictionFacadeInterface;
 use Generated\Shared\Transfer\CartChangeTransfer;
 use Generated\Shared\Transfer\ItemTransfer;
-use Laminas\Stdlib\ArrayObject;
 
 class CartCheckerTest extends Unit
 {

--- a/bundles/product-locale-restriction-storage/tests/FondOfOryx/Client/ProductLocaleRestrictionStorage/Plugin/ProductStorageExtension/ProductLocaleRestrictionStorageProductAbstractRestrictionPluginTest.php
+++ b/bundles/product-locale-restriction-storage/tests/FondOfOryx/Client/ProductLocaleRestrictionStorage/Plugin/ProductStorageExtension/ProductLocaleRestrictionStorageProductAbstractRestrictionPluginTest.php
@@ -4,6 +4,7 @@ namespace FondOfOryx\Client\ProductLocaleRestrictionStorage\Plugin\ProductStorag
 
 use Codeception\Test\Unit;
 use FondOfOryx\Client\ProductLocaleRestrictionStorage\ProductLocaleRestrictionStorageClient;
+use Spryker\Client\Kernel\AbstractClient;
 
 class ProductLocaleRestrictionStorageProductAbstractRestrictionPluginTest extends Unit
 {
@@ -30,8 +31,33 @@ class ProductLocaleRestrictionStorageProductAbstractRestrictionPluginTest extend
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->plugin = new ProductLocaleRestrictionStorageProductAbstractRestrictionPlugin();
-        $this->plugin->setClient($this->clientMock);
+        if (method_exists(ProductLocaleRestrictionStorageProductAbstractRestrictionPlugin::class, 'setClient')) {
+            $this->plugin = new ProductLocaleRestrictionStorageProductAbstractRestrictionPlugin();
+            $this->plugin->setClient($this->clientMock);
+        } else {
+            $this->plugin = new class ($this->clientMock) extends ProductLocaleRestrictionStorageProductAbstractRestrictionPlugin {
+                /**
+                 * @var \Spryker\Client\Kernel\AbstractClient
+                 */
+                protected $productLocaleRestrictionStorageClient;
+
+                /**
+                 * @param \Spryker\Client\Kernel\AbstractClient $client
+                 */
+                public function __construct(AbstractClient $client)
+                {
+                    $this->productLocaleRestrictionStorageClient = $client;
+                }
+
+                /**
+                 * @return \Spryker\Client\Kernel\AbstractClient
+                 */
+                protected function getClient(): AbstractClient
+                {
+                    return $this->productLocaleRestrictionStorageClient;
+                }
+            };
+        }
     }
 
     /**

--- a/bundles/product-locale-restriction-storage/tests/FondOfOryx/Zed/ProductLocaleRestrictionStorage/Communication/Plugin/Event/Subscriber/ProductLocaleRestrictionStorageEventSubscriberTest.php
+++ b/bundles/product-locale-restriction-storage/tests/FondOfOryx/Zed/ProductLocaleRestrictionStorage/Communication/Plugin/Event/Subscriber/ProductLocaleRestrictionStorageEventSubscriberTest.php
@@ -9,6 +9,7 @@ use FondOfOryx\Zed\ProductLocaleRestrictionStorage\Communication\Plugin\Event\Li
 use FondOfOryx\Zed\ProductLocaleRestrictionStorage\ProductLocaleRestrictionStorageConfig;
 use Spryker\Zed\Event\Dependency\EventCollectionInterface;
 use Spryker\Zed\Event\Dependency\Plugin\EventBaseHandlerInterface;
+use Spryker\Zed\Kernel\AbstractBundleConfig;
 use Spryker\Zed\Product\Dependency\ProductEvents;
 
 class ProductLocaleRestrictionStorageEventSubscriberTest extends Unit
@@ -43,8 +44,33 @@ class ProductLocaleRestrictionStorageEventSubscriberTest extends Unit
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->productLocaleRestrictionStorageEventSubscriber = new ProductLocaleRestrictionStorageEventSubscriber();
-        $this->productLocaleRestrictionStorageEventSubscriber->setConfig($this->configMock);
+        if (method_exists(ProductLocaleRestrictionStorageEventSubscriber::class, 'setConfig')) {
+            $this->productLocaleRestrictionStorageEventSubscriber = new ProductLocaleRestrictionStorageEventSubscriber();
+            $this->productLocaleRestrictionStorageEventSubscriber->setConfig($this->configMock);
+        } else {
+            $this->productLocaleRestrictionStorageEventSubscriber = new class ($this->configMock) extends ProductLocaleRestrictionStorageEventSubscriber {
+                /**
+                 * @var \Spryker\Zed\Kernel\AbstractBundleConfig
+                 */
+                protected $productLocaleRestrictionStorageConfig;
+
+                /**
+                 * @param \Spryker\Zed\Kernel\AbstractBundleConfig $config
+                 */
+                public function __construct(AbstractBundleConfig $config)
+                {
+                    $this->productLocaleRestrictionStorageConfig = $config;
+                }
+
+                /**
+                 * @return \Spryker\Zed\Kernel\AbstractBundleConfig
+                 */
+                protected function getConfig(): AbstractBundleConfig
+                {
+                    return $this->productLocaleRestrictionStorageConfig;
+                }
+            };
+        }
     }
 
     /**

--- a/bundles/product-locale-restriction-storage/tests/FondOfOryx/Zed/ProductLocaleRestrictionStorage/Communication/Plugin/Synchronization/ProductAbstractLocaleRestrictionStorageSynchronizationDataBulkPluginTest.php
+++ b/bundles/product-locale-restriction-storage/tests/FondOfOryx/Zed/ProductLocaleRestrictionStorage/Communication/Plugin/Synchronization/ProductAbstractLocaleRestrictionStorageSynchronizationDataBulkPluginTest.php
@@ -9,6 +9,7 @@ use FondOfOryx\Zed\ProductLocaleRestrictionStorage\ProductLocaleRestrictionStora
 use Generated\Shared\Transfer\FilterTransfer;
 use Generated\Shared\Transfer\FooProductAbstractLocaleRestrictionStorageEntityTransfer;
 use Orm\Zed\ProductLocaleRestrictionStorage\Persistence\Map\FooProductAbstractLocaleRestrictionStorageTableMap;
+use Spryker\Zed\Kernel\AbstractBundleConfig;
 
 class ProductAbstractLocaleRestrictionStorageSynchronizationDataBulkPluginTest extends Unit
 {
@@ -53,8 +54,34 @@ class ProductAbstractLocaleRestrictionStorageSynchronizationDataBulkPluginTest e
                 ->getMock(),
         ];
 
-        $this->productAbstractLocaleRestrictionStorageSynchronizationDataBulkPlugin = new ProductAbstractLocaleRestrictionStorageSynchronizationDataBulkPlugin();
-        $this->productAbstractLocaleRestrictionStorageSynchronizationDataBulkPlugin->setConfig($this->configMock);
+        if (method_exists(ProductAbstractLocaleRestrictionStorageSynchronizationDataBulkPlugin::class, 'setConfig')) {
+            $this->productAbstractLocaleRestrictionStorageSynchronizationDataBulkPlugin = new ProductAbstractLocaleRestrictionStorageSynchronizationDataBulkPlugin();
+            $this->productAbstractLocaleRestrictionStorageSynchronizationDataBulkPlugin->setConfig($this->configMock);
+        } else {
+            $this->productAbstractLocaleRestrictionStorageSynchronizationDataBulkPlugin = new class ($this->configMock) extends ProductAbstractLocaleRestrictionStorageSynchronizationDataBulkPlugin {
+                /**
+                 * @var \Spryker\Zed\Kernel\AbstractBundleConfig
+                 */
+                protected $productLocaleRestrictionStorageConfig;
+
+                /**
+                 * @param \Spryker\Zed\Kernel\AbstractBundleConfig $config
+                 */
+                public function __construct(AbstractBundleConfig $config)
+                {
+                    $this->productLocaleRestrictionStorageConfig = $config;
+                }
+
+                /**
+                 * @return \Spryker\Zed\Kernel\AbstractBundleConfig
+                 */
+                protected function getConfig(): AbstractBundleConfig
+                {
+                    return $this->productLocaleRestrictionStorageConfig;
+                }
+            };
+        }
+
         $this->productAbstractLocaleRestrictionStorageSynchronizationDataBulkPlugin->setRepository(
             $this->repositoryMock
         );


### PR DESCRIPTION
- setter for client, config and facade are missing in old versions of spryker kernel