### PR TITLE
Rename method of "QuoteExpanderPluginInterface"

### DIFF
--- a/bundles/splittable-totals-rest-api-company-unit-address-connector/src/FondOfOryx/Zed/SplittableTotalsRestApiCompanyUnitAddressConnector/Communication/Plugin/SplittableTotalsRestApiExtension/CompanyUnitAddressQuoteExpanderPlugin.php
+++ b/bundles/splittable-totals-rest-api-company-unit-address-connector/src/FondOfOryx/Zed/SplittableTotalsRestApiCompanyUnitAddressConnector/Communication/Plugin/SplittableTotalsRestApiExtension/CompanyUnitAddressQuoteExpanderPlugin.php
@@ -18,7 +18,7 @@ class CompanyUnitAddressQuoteExpanderPlugin extends AbstractPlugin implements Qu
      *
      * @return \Generated\Shared\Transfer\QuoteTransfer
      */
-    public function expandQuote(
+    public function expand(
         RestSplittableTotalsRequestTransfer $restSplittableTotalsRequestTransfer,
         QuoteTransfer $quoteTransfer
     ): QuoteTransfer {

--- a/bundles/splittable-totals-rest-api-company-unit-address-connector/tests/FondOfOryx/Zed/SplittableTotalsRestApiCompanyUnitAddressConnector/Communication/Plugin/SplittableTotalsRestApiExtension/CompanyUnitAddressQuoteExpanderPluginTest.php
+++ b/bundles/splittable-totals-rest-api-company-unit-address-connector/tests/FondOfOryx/Zed/SplittableTotalsRestApiCompanyUnitAddressConnector/Communication/Plugin/SplittableTotalsRestApiExtension/CompanyUnitAddressQuoteExpanderPluginTest.php
@@ -66,7 +66,7 @@ class CompanyUnitAddressQuoteExpanderPluginTest extends Unit
 
         static::assertEquals(
             $this->quoteTransferMock,
-            $this->companyUnitAddressQuoteExpanderPlugin->expandQuote(
+            $this->companyUnitAddressQuoteExpanderPlugin->expand(
                 $this->restSplittableTotalsRequestTransferMock,
                 $this->quoteTransferMock
             )

--- a/bundles/splittable-totals-rest-api-extension/src/FondOfOryx/Zed/SplittableTotalsRestApiExtension/Dependency/Plugin/QuoteExpanderPluginInterface.php
+++ b/bundles/splittable-totals-rest-api-extension/src/FondOfOryx/Zed/SplittableTotalsRestApiExtension/Dependency/Plugin/QuoteExpanderPluginInterface.php
@@ -13,7 +13,7 @@ interface QuoteExpanderPluginInterface
      *
      * @return \Generated\Shared\Transfer\QuoteTransfer
      */
-    public function expandQuote(
+    public function expand(
         RestSplittableTotalsRequestTransfer $restSplittableTotalsRequestTransfer,
         QuoteTransfer $quoteTransfer
     ): QuoteTransfer;

--- a/bundles/splittable-totals-rest-api-shipment-connector/src/FondOfOryx/Zed/SplittableTotalsRestApiShipmentConnector/Communication/Plugin/SplittableTotalsRestApiExtension/ShipmentQuoteExpanderPlugin.php
+++ b/bundles/splittable-totals-rest-api-shipment-connector/src/FondOfOryx/Zed/SplittableTotalsRestApiShipmentConnector/Communication/Plugin/SplittableTotalsRestApiExtension/ShipmentQuoteExpanderPlugin.php
@@ -18,7 +18,7 @@ class ShipmentQuoteExpanderPlugin extends AbstractPlugin implements QuoteExpande
      *
      * @return \Generated\Shared\Transfer\QuoteTransfer
      */
-    public function expandQuote(
+    public function expand(
         RestSplittableTotalsRequestTransfer $restSplittableTotalsRequestTransfer,
         QuoteTransfer $quoteTransfer
     ): QuoteTransfer {

--- a/bundles/splittable-totals-rest-api-shipment-connector/tests/FondOfOryx/Zed/SplittableTotalsRestApiShipmentConnector/Communication/Plugin/SplittableTotalsRestApiExtension/ShipmentQuoteExpanderPluginTest.php
+++ b/bundles/splittable-totals-rest-api-shipment-connector/tests/FondOfOryx/Zed/SplittableTotalsRestApiShipmentConnector/Communication/Plugin/SplittableTotalsRestApiExtension/ShipmentQuoteExpanderPluginTest.php
@@ -66,7 +66,7 @@ class ShipmentQuoteExpanderPluginTest extends Unit
 
         static::assertEquals(
             $this->quoteTransferMock,
-            $this->shipmentQuoteExpanderPlugin->expandQuote(
+            $this->shipmentQuoteExpanderPlugin->expand(
                 $this->restSplittableTotalsRequestTransferMock,
                 $this->quoteTransferMock
             )

--- a/bundles/splittable-totals-rest-api/src/FondOfOryx/Zed/SplittableTotalsRestApi/Business/Expander/QuoteExpander.php
+++ b/bundles/splittable-totals-rest-api/src/FondOfOryx/Zed/SplittableTotalsRestApi/Business/Expander/QuoteExpander.php
@@ -31,7 +31,7 @@ class QuoteExpander implements QuoteExpanderInterface
         QuoteTransfer $quoteTransfer
     ): QuoteTransfer {
         foreach ($this->quoteExpanderPlugins as $quoteExpanderPlugin) {
-            $quoteTransfer = $quoteExpanderPlugin->expandQuote($restSplittableTotalsRequestTransfer, $quoteTransfer);
+            $quoteTransfer = $quoteExpanderPlugin->expand($restSplittableTotalsRequestTransfer, $quoteTransfer);
         }
 
         return $quoteTransfer;

--- a/bundles/splittable-totals-rest-api/tests/FondOfOryx/Zed/SplittableTotalsRestApi/Business/Expander/QuoteExpanderTest.php
+++ b/bundles/splittable-totals-rest-api/tests/FondOfOryx/Zed/SplittableTotalsRestApi/Business/Expander/QuoteExpanderTest.php
@@ -59,7 +59,7 @@ class QuoteExpanderTest extends Unit
     public function testExpand(): void
     {
         $this->quoteExpanderPluginMocks[0]->expects(static::atLeastOnce())
-            ->method('expandQuote')
+            ->method('expand')
             ->with($this->restSplittableTotalsRequestTransferMock, $this->quoteTransferMock)
             ->willReturn($this->quoteTransferMock);
 


### PR DESCRIPTION
- use "expand" instead of "expandQuote"