### PR TITLE
📧 feature: sending emails in bcc

### DIFF
--- a/bundles/company-oms-mail-connector/src/FondOfOryx/Shared/CompanyOmsMailConnector/Transfer/company_oms_mail_connector.transfer.xml
+++ b/bundles/company-oms-mail-connector/src/FondOfOryx/Shared/CompanyOmsMailConnector/Transfer/company_oms_mail_connector.transfer.xml
@@ -5,10 +5,14 @@
 
     <transfer name="Order">
         <property name="companyUserReference" type="string"/>
+        <property name="email" type="string"/>
+        <property name="firstName" type="string"/>
+        <property name="lastName" type="string"/>
     </transfer>
 
     <transfer name="Mail">
         <property name="companyUser" type="CompanyUser"/>
+        <property name="order" type="Order"/>
     </transfer>
 
     <transfer name="Company">

--- a/bundles/company-oms-mail-connector/src/FondOfOryx/Zed/CompanyOmsMailConnector/Business/Expander/MailExpander.php
+++ b/bundles/company-oms-mail-connector/src/FondOfOryx/Zed/CompanyOmsMailConnector/Business/Expander/MailExpander.php
@@ -67,11 +67,13 @@ class MailExpander implements ExpanderInterface
             return $mailTransfer;
         }
 
-        return $mailTransfer->addRecipientBcc(
+        $mailTransfer->addRecipientBcc(
             (new MailRecipientTransfer())
                 ->setEmail($orderTransfer->getEmail())
                 ->setName($orderTransfer->getFirstName() . ' ' . $orderTransfer->getLastName()),
         );
+
+        return $mailTransfer;
     }
 
     /**

--- a/bundles/company-oms-mail-connector/src/FondOfOryx/Zed/CompanyOmsMailConnector/Business/Expander/MailExpander.php
+++ b/bundles/company-oms-mail-connector/src/FondOfOryx/Zed/CompanyOmsMailConnector/Business/Expander/MailExpander.php
@@ -67,13 +67,11 @@ class MailExpander implements ExpanderInterface
             return $mailTransfer;
         }
 
-        $mailTransfer->addRecipientBcc(
+        return $mailTransfer->addRecipientBcc(
             (new MailRecipientTransfer())
                 ->setEmail($orderTransfer->getEmail())
                 ->setName($orderTransfer->getFirstName() . ' ' . $orderTransfer->getLastName()),
         );
-
-        return $mailTransfer;
     }
 
     /**

--- a/bundles/company-oms-mail-connector/src/FondOfOryx/Zed/CompanyOmsMailConnector/Business/Expander/MailExpander.php
+++ b/bundles/company-oms-mail-connector/src/FondOfOryx/Zed/CompanyOmsMailConnector/Business/Expander/MailExpander.php
@@ -36,24 +36,42 @@ class MailExpander implements ExpanderInterface
         $companyBusinessUnitTransfer = $this->getCompanyBusinessUnit($this->getCompanyUser($mailTransfer, $orderTransfer));
         $recipientMailAddress = $companyBusinessUnitTransfer->getEmail();
 
-        if ($recipientMailAddress !== null && $this->isRecipient($recipientMailAddress, $mailTransfer) === false) {
+        if ($recipientMailAddress === null) {
+            return $mailTransfer;
+        }
+
+        if ($this->isRecipient($recipientMailAddress, $mailTransfer) === false) {
             $recipientTransfer = (new MailRecipientTransfer())->setEmail($recipientMailAddress)->setName($companyBusinessUnitTransfer->getName());
             $mailTransfer->addRecipient($recipientTransfer);
         }
 
+        return $this->addRecipientBcc($mailTransfer, $orderTransfer, $recipientMailAddress);
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\MailTransfer $mailTransfer
+     * @param \Generated\Shared\Transfer\OrderTransfer $orderTransfer
+     * @param string $recipientMailAddress
+     *
+     * @return \Generated\Shared\Transfer\MailTransfer
+     */
+    protected function addRecipientBcc(
+        MailTransfer $mailTransfer,
+        OrderTransfer $orderTransfer,
+        string $recipientMailAddress
+    ): MailTransfer {
         if (
-            $recipientMailAddress !== null &&
-            $orderTransfer->getEmail() !== $recipientMailAddress &&
-            $this->isRecipient($orderTransfer->getEmail(), $mailTransfer) === false
+            $orderTransfer->getEmail() === $recipientMailAddress ||
+            $this->isRecipient($orderTransfer->getEmail(), $mailTransfer) === true
         ) {
-            $mailTransfer->addRecipientBcc(
-                (new MailRecipientTransfer())
-                    ->setEmail($orderTransfer->getEmail())
-                    ->setName($orderTransfer->getFirstName() . ' ' . $orderTransfer->getLastName()),
-            );
+            return $mailTransfer;
         }
 
-        return $mailTransfer;
+        return $mailTransfer->addRecipientBcc(
+            (new MailRecipientTransfer())
+                ->setEmail($orderTransfer->getEmail())
+                ->setName($orderTransfer->getFirstName() . ' ' . $orderTransfer->getLastName()),
+        );
     }
 
     /**

--- a/bundles/company-oms-mail-connector/src/FondOfOryx/Zed/CompanyOmsMailConnector/Communication/Plugin/Mail/OrderConfirmationMailTypePlugin.php
+++ b/bundles/company-oms-mail-connector/src/FondOfOryx/Zed/CompanyOmsMailConnector/Communication/Plugin/Mail/OrderConfirmationMailTypePlugin.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace FondOfOryx\Zed\CompanyOmsMailConnector\Communication\Plugin\Mail;
+
+use Spryker\Zed\Kernel\Communication\AbstractPlugin;
+use Spryker\Zed\Mail\Business\Model\Mail\Builder\MailBuilderInterface;
+use Spryker\Zed\Mail\Dependency\Plugin\MailTypePluginInterface;
+
+class OrderConfirmationMailTypePlugin extends AbstractPlugin implements MailTypePluginInterface
+{
+    /**
+     * @var string
+     */
+    public const MAIL_TYPE = 'order confirmation mail';
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return static::MAIL_TYPE;
+    }
+
+    /**
+     * @param \Spryker\Zed\Mail\Business\Model\Mail\Builder\MailBuilderInterface $mailBuilder
+     *
+     * @return void
+     */
+    public function build(MailBuilderInterface $mailBuilder): void
+    {
+        $this
+            ->setSubject($mailBuilder)
+            ->setHtmlTemplate($mailBuilder)
+            ->setTextTemplate($mailBuilder)
+            ->setSender($mailBuilder);
+    }
+
+    /**
+     * @param \Spryker\Zed\Mail\Business\Model\Mail\Builder\MailBuilderInterface $mailBuilder
+     *
+     * @return $this
+     */
+    protected function setSubject(MailBuilderInterface $mailBuilder)
+    {
+        $mailBuilder->setSubject('mail.order.confirmation.subject');
+
+        return $this;
+    }
+
+    /**
+     * @param \Spryker\Zed\Mail\Business\Model\Mail\Builder\MailBuilderInterface $mailBuilder
+     *
+     * @return $this
+     */
+    protected function setHtmlTemplate(MailBuilderInterface $mailBuilder)
+    {
+        $mailBuilder->setHtmlTemplate('oms/mail/order_confirmation.html.twig');
+
+        return $this;
+    }
+
+    /**
+     * @param \Spryker\Zed\Mail\Business\Model\Mail\Builder\MailBuilderInterface $mailBuilder
+     *
+     * @return $this
+     */
+    protected function setTextTemplate(MailBuilderInterface $mailBuilder)
+    {
+        $mailBuilder->setTextTemplate('oms/mail/order_confirmation.text.twig');
+
+        return $this;
+    }
+
+    /**
+     * @param \Spryker\Zed\Mail\Business\Model\Mail\Builder\MailBuilderInterface $mailBuilder
+     *
+     * @return $this
+     */
+    protected function setSender(MailBuilderInterface $mailBuilder)
+    {
+        $mailBuilder->useDefaultSender();
+
+        return $this;
+    }
+}

--- a/bundles/company-oms-mail-connector/tests/FondOfOryx/Zed/CompanyOmsMailConnector/Business/Expander/MailExpanderTest.php
+++ b/bundles/company-oms-mail-connector/tests/FondOfOryx/Zed/CompanyOmsMailConnector/Business/Expander/MailExpanderTest.php
@@ -93,6 +93,7 @@ class MailExpanderTest extends Unit
         $this->companyBusinessUnitTransferTransferMock->expects(static::once())->method('getEmail')->willReturn('unit@codeception.test');
         $this->companyBusinessUnitTransferTransferMock->expects(static::once())->method('getName')->willReturn('FOO Company GmbH');
         $this->orderTransferMock->expects(static::atLeastOnce())->method('getEmail')->willReturn('order@codeception.test');
+        $this->mailTransferMock->expects(static::atLeastOnce())->method('addRecipientBcc')->willReturnSelf();
 
         $this->expander->expand($this->mailTransferMock, $this->orderTransferMock);
     }
@@ -115,6 +116,7 @@ class MailExpanderTest extends Unit
         $this->companyBusinessUnitTransferTransferMock->expects(static::once())->method('getEmail')->willReturn('unit@codeception.test');
         $this->mailRecipientTransferMock->expects(static::atLeastOnce())->method('getEmail')->willReturn('unit@codeception.test');
         $this->orderTransferMock->expects(static::atLeastOnce())->method('getEmail')->willReturn('order@codeception.test');
+        $this->mailTransferMock->expects(static::atLeastOnce())->method('addRecipientBcc')->willReturnSelf();
 
         $this->expander->expand($this->mailTransferMock, $this->orderTransferMock);
     }
@@ -140,6 +142,7 @@ class MailExpanderTest extends Unit
         $this->companyBusinessUnitTransferTransferMock->expects(static::once())->method('getEmail')->willReturn('unit@codeception.test');
         $this->companyBusinessUnitTransferTransferMock->expects(static::once())->method('getName')->willReturn('FOO Company GmbH');
         $this->orderTransferMock->expects(static::atLeastOnce())->method('getEmail')->willReturn('order@codeception.test');
+        $this->mailTransferMock->expects(static::atLeastOnce())->method('addRecipientBcc')->willReturnSelf();
 
         $this->expander->expand($this->mailTransferMock, $this->orderTransferMock);
     }

--- a/bundles/company-oms-mail-connector/tests/FondOfOryx/Zed/CompanyOmsMailConnector/Business/Expander/MailExpanderTest.php
+++ b/bundles/company-oms-mail-connector/tests/FondOfOryx/Zed/CompanyOmsMailConnector/Business/Expander/MailExpanderTest.php
@@ -82,7 +82,7 @@ class MailExpanderTest extends Unit
         $this->companyUserTransferTransferMock->expects(static::never())->method('getCompanyUserReference');
         $this->companyUserTransferTransferMock->expects(static::once())->method('getCompanyBusinessUnit')->willReturn($this->companyBusinessUnitTransferTransferMock);
         $this->mailTransferMock->expects(static::once())->method('setCompanyUser')->with($this->companyUserTransferTransferMock)->willReturnSelf();
-        $this->mailTransferMock->expects(static::once())->method('getRecipients')->willReturn(new ArrayObject());
+        $this->mailTransferMock->expects(static::atLeastOnce())->method('getRecipients')->willReturn(new ArrayObject());
         $this->mailTransferMock->expects(static::once())->method('addRecipient')->willReturnCallback(static function (MailRecipientTransfer $recipientTransfer) {
             static::assertSame($recipientTransfer->getName(), 'FOO Company GmbH');
             static::assertSame($recipientTransfer->getEmail(), 'unit@codeception.test');
@@ -92,6 +92,7 @@ class MailExpanderTest extends Unit
         $this->companyUserResponseTransferMock->expects(static::once())->method('getCompanyUser')->willReturn($this->companyUserTransferTransferMock);
         $this->companyBusinessUnitTransferTransferMock->expects(static::once())->method('getEmail')->willReturn('unit@codeception.test');
         $this->companyBusinessUnitTransferTransferMock->expects(static::once())->method('getName')->willReturn('FOO Company GmbH');
+        $this->orderTransferMock->expects(static::atLeastOnce())->method('getEmail')->willReturn('order@codeception.test');
 
         $this->expander->expand($this->mailTransferMock, $this->orderTransferMock);
     }
@@ -106,13 +107,14 @@ class MailExpanderTest extends Unit
         $this->companyUserTransferTransferMock->expects(static::never())->method('getCompanyUserReference');
         $this->companyUserTransferTransferMock->expects(static::once())->method('getCompanyBusinessUnit')->willReturn($this->companyBusinessUnitTransferTransferMock);
         $this->mailTransferMock->expects(static::once())->method('setCompanyUser')->with($this->companyUserTransferTransferMock)->willReturnSelf();
-        $this->mailTransferMock->expects(static::once())->method('getRecipients')->willReturn(new ArrayObject([$this->mailRecipientTransferMock]));
+        $this->mailTransferMock->expects(static::atLeastOnce())->method('getRecipients')->willReturn(new ArrayObject([$this->mailRecipientTransferMock]));
         $this->mailTransferMock->expects(static::never())->method('addRecipient');
         $this->companyUserReferenceFacadeMock->expects(static::once())->method('findCompanyUserByCompanyUserReference')->willReturn($this->companyUserResponseTransferMock);
         $this->companyUserResponseTransferMock->expects(static::once())->method('getIsSuccessful')->willReturn(true);
         $this->companyUserResponseTransferMock->expects(static::once())->method('getCompanyUser')->willReturn($this->companyUserTransferTransferMock);
         $this->companyBusinessUnitTransferTransferMock->expects(static::once())->method('getEmail')->willReturn('unit@codeception.test');
-        $this->mailRecipientTransferMock->expects(static::once())->method('getEmail')->willReturn('unit@codeception.test');
+        $this->mailRecipientTransferMock->expects(static::atLeastOnce())->method('getEmail')->willReturn('unit@codeception.test');
+        $this->orderTransferMock->expects(static::atLeastOnce())->method('getEmail')->willReturn('order@codeception.test');
 
         $this->expander->expand($this->mailTransferMock, $this->orderTransferMock);
     }
@@ -127,7 +129,7 @@ class MailExpanderTest extends Unit
         $this->companyUserTransferTransferMock->expects(static::once())->method('getCompanyUserReference')->willReturn('companyUserReference');
         $this->companyUserTransferTransferMock->expects(static::once())->method('getCompanyBusinessUnit')->willReturn($this->companyBusinessUnitTransferTransferMock);
         $this->mailTransferMock->expects(static::never())->method('setCompanyUser');
-        $this->mailTransferMock->expects(static::once())->method('getRecipients')->willReturn(new ArrayObject());
+        $this->mailTransferMock->expects(static::atLeastOnce())->method('getRecipients')->willReturn(new ArrayObject());
         $this->mailTransferMock->expects(static::once())->method('addRecipient')->willReturnCallback(static function (MailRecipientTransfer $recipientTransfer) {
             static::assertSame($recipientTransfer->getName(), 'FOO Company GmbH');
             static::assertSame($recipientTransfer->getEmail(), 'unit@codeception.test');
@@ -137,6 +139,7 @@ class MailExpanderTest extends Unit
         $this->companyUserResponseTransferMock->expects(static::never())->method('getCompanyUser');
         $this->companyBusinessUnitTransferTransferMock->expects(static::once())->method('getEmail')->willReturn('unit@codeception.test');
         $this->companyBusinessUnitTransferTransferMock->expects(static::once())->method('getName')->willReturn('FOO Company GmbH');
+        $this->orderTransferMock->expects(static::atLeastOnce())->method('getEmail')->willReturn('order@codeception.test');
 
         $this->expander->expand($this->mailTransferMock, $this->orderTransferMock);
     }

--- a/bundles/company-oms-mail-connector/tests/FondOfOryx/Zed/CompanyOmsMailConnector/Communication/Plugin/Mail/OrderConfirmationMailTypePluginTest.php
+++ b/bundles/company-oms-mail-connector/tests/FondOfOryx/Zed/CompanyOmsMailConnector/Communication/Plugin/Mail/OrderConfirmationMailTypePluginTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace FondOfOryx\Zed\CompanyOmsMailConnector\Communication\Plugin\Mail;
+
+use Codeception\Test\Unit;
+use Spryker\Zed\Mail\Business\Model\Mail\Builder\MailBuilder;
+
+class OrderConfirmationMailTypePluginTest extends Unit
+{
+    /**
+     * @var \FondOfOryx\Zed\CompanyOmsMailConnector\Communication\Plugin\Mail\OrderConfirmationMailTypePlugin
+     */
+    protected $orderConfirmationMailTypePlugin;
+
+    /**
+     * @var \Spryker\Zed\Mail\Business\Model\Mail\Builder\MailBuilderInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $mailBuilderMock;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        parent::_before();
+
+        $this->mailBuilderMock = $this->getMockBuilder(MailBuilder::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->orderConfirmationMailTypePlugin = new OrderConfirmationMailTypePlugin();
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuild(): void
+    {
+        $this->mailBuilderMock->expects(static::atLeastOnce())
+            ->method('setSubject');
+
+        $this->mailBuilderMock->expects(static::atLeastOnce())
+            ->method('setHtmlTemplate');
+
+        $this->mailBuilderMock->expects(static::atLeastOnce())
+            ->method('setTextTemplate');
+
+        $this->mailBuilderMock->expects(static::atLeastOnce())
+            ->method('useDefaultSender');
+
+        $this->orderConfirmationMailTypePlugin->build($this->mailBuilderMock);
+    }
+}

--- a/bundles/company-oms-mail-connector/tests/FondOfOryx/Zed/CompanyOmsMailConnector/Communication/Plugin/Oms/CompanyEmailOmsOrderMailExpanderPluginTest.php
+++ b/bundles/company-oms-mail-connector/tests/FondOfOryx/Zed/CompanyOmsMailConnector/Communication/Plugin/Oms/CompanyEmailOmsOrderMailExpanderPluginTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace FondOfOryx\Zed\CompanyOmsMailConnector\Communication\Plugin\Oms;
+
+use Codeception\Test\Unit;
+use FondOfOryx\Zed\CompanyOmsMailConnector\Business\CompanyOmsMailConnectorFacade;
+use Generated\Shared\Transfer\MailTransfer;
+use Generated\Shared\Transfer\OrderTransfer;
+
+class CompanyEmailOmsOrderMailExpanderPluginTest extends Unit
+{
+    /**
+     * @var \FondOfOryx\Zed\CompanyOmsMailConnector\Communication\Plugin\Oms\CompanyEmailOmsOrderMailExpanderPlugin
+     */
+    protected $companyEmailOmsOrderMailExpanderPlugin;
+
+    /**
+     * @var \Generated\Shared\Transfer\MailTransfer|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $mailTransferMock;
+
+    /**
+     * @var \Generated\Shared\Transfer\OrderTransfer|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $orderTransferMock;
+
+    /**
+     * @var \FondOfOryx\Zed\CompanyOmsMailConnector\Business\CompanyOmsMailConnectorFacade|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $companyOmsMailConnectorFacadeMock;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        parent::_before();
+
+        $this->mailTransferMock = $this->getMockBuilder(MailTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->orderTransferMock = $this->getMockBuilder(OrderTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companyOmsMailConnectorFacadeMock = $this->getMockBuilder(CompanyOmsMailConnectorFacade::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companyEmailOmsOrderMailExpanderPlugin = new CompanyEmailOmsOrderMailExpanderPlugin();
+        $this->companyEmailOmsOrderMailExpanderPlugin->setFacade($this->companyOmsMailConnectorFacadeMock);
+    }
+
+    /**
+     * @return void
+     */
+    public function testExpand(): void
+    {
+        $this->companyOmsMailConnectorFacadeMock->expects(static::atLeastOnce())
+            ->method('expandOrderMailTransferWithCompanyMailAddress')
+            ->with($this->mailTransferMock, $this->orderTransferMock)
+            ->willReturn($this->mailTransferMock);
+
+        $mailTransfer = $this->companyEmailOmsOrderMailExpanderPlugin->expand(
+            $this->mailTransferMock,
+            $this->orderTransferMock,
+        );
+
+        static::assertEquals($mailTransfer, $this->mailTransferMock);
+    }
+}

--- a/bundles/company-oms-mail-connector/tests/FondOfOryx/Zed/CompanyOmsMailConnector/Communication/Plugin/Oms/CompanyLocaleOmsOrderMailExpanderPluginTest.php
+++ b/bundles/company-oms-mail-connector/tests/FondOfOryx/Zed/CompanyOmsMailConnector/Communication/Plugin/Oms/CompanyLocaleOmsOrderMailExpanderPluginTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace FondOfOryx\Zed\CompanyOmsMailConnector\Communication\Plugin\Oms;
+
+use Codeception\Test\Unit;
+use FondOfOryx\Zed\CompanyOmsMailConnector\Business\CompanyOmsMailConnectorFacade;
+use Generated\Shared\Transfer\MailTransfer;
+use Generated\Shared\Transfer\OrderTransfer;
+
+class CompanyLocaleOmsOrderMailExpanderPluginTest extends Unit
+{
+    /**
+     * @var \FondOfOryx\Zed\CompanyOmsMailConnector\Communication\Plugin\Oms\CompanyLocaleOmsOrderMailExpanderPlugin
+     */
+    protected $companyLocaleOmsOrderMailExpanderPlugin;
+
+    /**
+     * @var \Generated\Shared\Transfer\MailTransfer|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $mailTransferMock;
+
+    /**
+     * @var \Generated\Shared\Transfer\OrderTransfer|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $orderTransferMock;
+
+    /**
+     * @var \FondOfOryx\Zed\CompanyOmsMailConnector\Business\CompanyOmsMailConnectorFacade|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $companyOmsMailConnectorFacadeMock;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        parent::_before();
+
+        $this->mailTransferMock = $this->getMockBuilder(MailTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->orderTransferMock = $this->getMockBuilder(OrderTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companyOmsMailConnectorFacadeMock = $this->getMockBuilder(CompanyOmsMailConnectorFacade::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companyLocaleOmsOrderMailExpanderPlugin = new CompanyLocaleOmsOrderMailExpanderPlugin();
+        $this->companyLocaleOmsOrderMailExpanderPlugin->setFacade($this->companyOmsMailConnectorFacadeMock);
+    }
+
+    /**
+     * @return void
+     */
+    public function testExpand(): void
+    {
+        $this->companyOmsMailConnectorFacadeMock->expects(static::atLeastOnce())
+            ->method('expandOrderMailTransferWithCompanyLocale')
+            ->with($this->mailTransferMock, $this->orderTransferMock)
+            ->willReturn($this->mailTransferMock);
+
+        $mailTransfer = $this->companyLocaleOmsOrderMailExpanderPlugin->expand(
+            $this->mailTransferMock,
+            $this->orderTransferMock,
+        );
+
+        static::assertEquals($mailTransfer, $this->mailTransferMock);
+    }
+}

--- a/dandelion.json
+++ b/dandelion.json
@@ -96,7 +96,7 @@
     },
     "company-oms-mail-connector": {
       "path": "bundles/company-oms-mail-connector/",
-      "version": "1.1.1"
+      "version": "2.0.0"
     },
     "company-price-lists-rest-api": {
       "path": "bundles/company-price-lists-rest-api/",


### PR DESCRIPTION
Changelog:

- new custom OrderConfirmationMailTypePlugin
- send email in bcc
- add missing properties to transfer
- complete unit-tests
- fix typing error
- increase version to 2.0.0