### PR TITLE
🚛 return-labels-rest-api-company-connector

### DIFF
--- a/bundles/return-labels-rest-api-company-connector/src/FondOfOryx/Shared/ReturnLabelsRestApiCompanyConnector/Transfer/return_labels_rest_api_company_connector.transfer.xml
+++ b/bundles/return-labels-rest-api-company-connector/src/FondOfOryx/Shared/ReturnLabelsRestApiCompanyConnector/Transfer/return_labels_rest_api_company_connector.transfer.xml
@@ -14,7 +14,6 @@
 
     <transfer name="ReturnLabelRequest">
         <property name="customer" type="ReturnLabelRequestCustomer"/>
-        <property name="reference" type="string"/>
     </transfer>
 
     <transfer name="ReturnLabelRequestCustomer"/>


### PR DESCRIPTION
**Changelog**

- remove unused property "reference" from ReturnLabelRequestTransfer