### PR TITLE
🪲 bugfix: customer-registration-one-time-password-connector

### DIFF
--- a/bundles/customer-registration-one-time-password-connector/composer.json
+++ b/bundles/customer-registration-one-time-password-connector/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "php": ">=8.0",
-    "fond-of-oryx/customer-registration-plugin": "^2.0.0",
+    "fond-of-oryx/customer-registration": "^2.0.0",
     "fond-of-oryx/one-time-password": "^1.1.0 || ^2.0.0",
     "spryker/locale": "^2.2.0 || ^3.0.0"
   },


### PR DESCRIPTION
**Description**

The customer-registration-plugin package does not exist, before the update (3dfa681 ) it was customer-registration. Maybe a typo?

![image](https://user-images.githubusercontent.com/35733274/216066243-f86041ed-f044-473a-8490-9b368dfc0f69.png)
