### PR TITLE
🐛 Use consistent naming for es index (erp-order) properties

### DIFF
--- a/bundles/erp-order-page-search/src/FondOfOryx/Shared/ErpOrderPageSearch/Schema/erp-order.json
+++ b/bundles/erp-order-page-search/src/FondOfOryx/Shared/ErpOrderPageSearch/Schema/erp-order.json
@@ -43,7 +43,7 @@
           "type": "date",
           "format": "yyyy-MM-dd HH:mm:ss.SSSSSS||yyyy-MM-dd HH:mm:ss||yyyy-MM-dd HH:mm:ss.SSSSSSZ"
         },
-        "created_at": {
+        "created-at": {
           "type": "date",
           "format": "yyyy-MM-dd HH:mm:ss.SSSSSS||yyyy-MM-dd HH:mm:ss||yyyy-MM-dd HH:mm:ss.SSSSSSZ"
         },


### PR DESCRIPTION
- use '-' instead of '_'
- ...