### PR TITLE
🐛 Use max value for price to pay

### DIFF
--- a/bundles/shipment-table-rate/src/FondOfOryx/Zed/ShipmentTableRate/Business/Model/ShipmentTableRateReader.php
+++ b/bundles/shipment-table-rate/src/FondOfOryx/Zed/ShipmentTableRate/Business/Model/ShipmentTableRateReader.php
@@ -17,6 +17,11 @@ use Generated\Shared\Transfer\TotalsTransfer;
 class ShipmentTableRateReader implements ShipmentTableRateReaderInterface
 {
     /**
+     * @var int
+     */
+    protected const MAX_PRICE_TO_PAY = 2147483647;
+
+    /**
      * @var \FondOfOryx\Zed\ShipmentTableRate\Business\Model\ZipCodePatternsGeneratorInterface
      */
     protected $zipCodePatternsGenerator;
@@ -120,7 +125,7 @@ class ShipmentTableRateReader implements ShipmentTableRateReaderInterface
         return (new ShipmentTableRateCriteriaFilterTransfer())
             ->setFkCountry($countryTransfer->getIdCountry())
             ->setFkStore($storeTransfer->getIdStore())
-            ->setPriceToPay($priceToPay)
+            ->setPriceToPay(min($priceToPay, static::MAX_PRICE_TO_PAY))
             ->setZipCodePatterns($this->zipCodePatternsGenerator->generateFromZipCode($zipCode));
     }
 }

--- a/dandelion.json
+++ b/dandelion.json
@@ -728,7 +728,7 @@
     },
     "shipment-table-rate": {
       "path": "bundles/shipment-table-rate/",
-      "version": "2.0.0"
+      "version": "2.0.1"
     },
     "shipment-table-rate-data-import": {
       "path": "bundles/shipment-table-rate-data-import/",


### PR DESCRIPTION
- table columns "min_price_to_pay" and "max_price_to_pay" allows ranges from -2147483648 to +2147483647
- set the limit of 2147483647 for price to pay (if greater select statement will be broken)
- ...