### PR TITLE
🧩 feature: checkout rest api payone connector

### DIFF
--- a/bundles/checkout-rest-api-payone-connector/composer.json
+++ b/bundles/checkout-rest-api-payone-connector/composer.json
@@ -16,7 +16,7 @@
   ],
   "require": {
     "php": ">=8.0",
-    "spryker/checkout-rest-api-extension": "^3.0.0",
+    "spryker/checkout-rest-api-extension": "^1.4.0",
     "spryker-eco/payone": "dev-master-fondof as 4.4.2"
   },
   "require-dev": {

--- a/bundles/checkout-rest-api-payone-connector/composer.json
+++ b/bundles/checkout-rest-api-payone-connector/composer.json
@@ -16,7 +16,7 @@
   ],
   "require": {
     "php": ">=8.0",
-    "spryker/checkout-rest-api-extension": "^1.4.0",
+    "spryker/checkout-rest-api-extension": "^1.5.0",
     "spryker-eco/payone": "dev-master-fondof as 4.4.2"
   },
   "require-dev": {

--- a/dandelion.json
+++ b/dandelion.json
@@ -54,6 +54,10 @@
       "path": "bundles/cart-search-rest-api-extension/",
       "version": "2.0.0"
     },
+    "checkout-rest-api-payone-connector": {
+      "path": "bundles/checkout-rest-api-payone-connector/",
+      "version": "1.0.0-alpha.0"
+    },
     "catalog-sku-filter": {
       "path": "bundles/catalog-sku-filter/",
       "version": "2.0.0"


### PR DESCRIPTION
**Changelog**

Version 3.0.0 of spryker/checkout-rest-api-extension does not exist. The first compatible version is 1.4.0