### PR TITLE
✨ Implement zed contracts to `business-on-behalf-rest-api`-bundle

### DIFF
--- a/bundles/business-on-behalf-rest-api/src/FondOfOryx/Shared/BusinessOnBehalfRestApi/BusinessOnBehalfRestApiConstants.php
+++ b/bundles/business-on-behalf-rest-api/src/FondOfOryx/Shared/BusinessOnBehalfRestApi/BusinessOnBehalfRestApiConstants.php
@@ -7,6 +7,16 @@ interface BusinessOnBehalfRestApiConstants
     /**
      * @var string
      */
+    public const ERROR_MESSAGE_INVALID_COMPANY_USER = 'Company user is invalid.';
+
+    /**
+     * @var string
+     */
+    public const ERROR_CODE_INVALID_COMPANY_USER = '5002';
+
+    /**
+     * @var string
+     */
     public const ERROR_MESSAGE_COMPANY_USER_NOT_FOUND = 'Company user not found.';
 
     /**

--- a/bundles/business-on-behalf-rest-api/src/FondOfOryx/Shared/BusinessOnBehalfRestApi/BusinessOnBehalfRestApiConstants.php
+++ b/bundles/business-on-behalf-rest-api/src/FondOfOryx/Shared/BusinessOnBehalfRestApi/BusinessOnBehalfRestApiConstants.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace FondOfOryx\Shared\BusinessOnBehalfRestApi;
+
+interface BusinessOnBehalfRestApiConstants
+{
+    /**
+     * @var string
+     */
+    public const ERROR_MESSAGE_COMPANY_USER_NOT_FOUND = 'Company user not found.';
+
+    /**
+     * @var string
+     */
+    public const ERROR_CODE_COMPANY_USER_NOT_FOUND = '5001';
+
+    /**
+     * @var string
+     */
+    public const ERROR_MESSAGE_UNDEFINED_ERROR_OCCURRED = 'Undefined error occurred.';
+
+    /**
+     * @var string
+     */
+    public const ERROR_CODE_UNDEFINED_ERROR_OCCURRED = '5000';
+}

--- a/bundles/business-on-behalf-rest-api/src/FondOfOryx/Shared/BusinessOnBehalfRestApi/Transfer/business_on_behalf_rest_api.transfer.xml
+++ b/bundles/business-on-behalf-rest-api/src/FondOfOryx/Shared/BusinessOnBehalfRestApi/Transfer/business_on_behalf_rest_api.transfer.xml
@@ -17,7 +17,7 @@
     </transfer>
 
     <transfer name="RestBusinessOnBehalfError">
-        <property name="errorCode" type="int"/>
+        <property name="errorCode" type="string"/>
         <property name="message" type="string"/>
         <property name="parameters" type="array" singular="parameters"/>
     </transfer>

--- a/bundles/business-on-behalf-rest-api/src/FondOfOryx/Zed/BusinessOnBehalfRestApi/Business/BusinessOnBehalfRestApiBusinessFactory.php
+++ b/bundles/business-on-behalf-rest-api/src/FondOfOryx/Zed/BusinessOnBehalfRestApi/Business/BusinessOnBehalfRestApiBusinessFactory.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace FondOfOryx\Zed\BusinessOnBehalfRestApi\Business;
+
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\Reader\CompanyUserReader;
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\Reader\CompanyUserReaderInterface;
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\Writer\CompanyUserWriter;
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\Writer\CompanyUserWriterInterface;
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\BusinessOnBehalfRestApiDependencyProvider;
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToBusinessOnBehalfFacadeInterface;
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToCompanyUserFacadeInterface;
+use Spryker\Zed\Kernel\Business\AbstractBusinessFactory;
+
+/**
+ * @method \FondOfOryx\Zed\BusinessOnBehalfRestApi\Persistence\BusinessOnBehalfRestApiRepositoryInterface getRepository()
+ */
+class BusinessOnBehalfRestApiBusinessFactory extends AbstractBusinessFactory
+{
+    /**
+     * @return \FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\Writer\CompanyUserWriterInterface
+     */
+    public function createCompanyUserWriter(): CompanyUserWriterInterface
+    {
+        return new CompanyUserWriter(
+            $this->createCompanyUserReader(),
+            $this->getBusinessOnBehalfFacade(),
+        );
+    }
+
+    /**
+     * @return \FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\Reader\CompanyUserReaderInterface
+     */
+    protected function createCompanyUserReader(): CompanyUserReaderInterface
+    {
+        return new CompanyUserReader(
+            $this->getCompanyUserFacade(),
+            $this->getRepository(),
+        );
+    }
+
+    /**
+     * @return \FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToCompanyUserFacadeInterface
+     */
+    protected function getCompanyUserFacade(): BusinessOnBehalfRestApiToCompanyUserFacadeInterface
+    {
+        return $this->getProvidedDependency(BusinessOnBehalfRestApiDependencyProvider::FACADE_COMPANY_USER);
+    }
+
+    /**
+     * @return \FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToBusinessOnBehalfFacadeInterface
+     */
+    protected function getBusinessOnBehalfFacade(): BusinessOnBehalfRestApiToBusinessOnBehalfFacadeInterface
+    {
+        return $this->getProvidedDependency(BusinessOnBehalfRestApiDependencyProvider::FACADE_BUSINESS_ON_BEHALF);
+    }
+}

--- a/bundles/business-on-behalf-rest-api/src/FondOfOryx/Zed/BusinessOnBehalfRestApi/Business/BusinessOnBehalfRestApiFacade.php
+++ b/bundles/business-on-behalf-rest-api/src/FondOfOryx/Zed/BusinessOnBehalfRestApi/Business/BusinessOnBehalfRestApiFacade.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace FondOfOryx\Zed\BusinessOnBehalfRestApi\Business;
+
+use Generated\Shared\Transfer\RestBusinessOnBehalfRequestTransfer;
+use Generated\Shared\Transfer\RestBusinessOnBehalfResponseTransfer;
+use Spryker\Zed\Kernel\Business\AbstractFacade;
+
+/**
+ * @method \FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\BusinessOnBehalfRestApiBusinessFactory getFactory()
+ */
+class BusinessOnBehalfRestApiFacade extends AbstractFacade implements BusinessOnBehalfRestApiFacadeInterface
+{
+    /**
+     * @param \Generated\Shared\Transfer\RestBusinessOnBehalfRequestTransfer $restBusinessOnBehalfRequestTransfer
+     *
+     * @return \Generated\Shared\Transfer\RestBusinessOnBehalfResponseTransfer
+     */
+    public function setDefaultCompanyUserByRestBusinessOnBehalfRequest(
+        RestBusinessOnBehalfRequestTransfer $restBusinessOnBehalfRequestTransfer
+    ): RestBusinessOnBehalfResponseTransfer {
+        return $this->getFactory()
+            ->createCompanyUserWriter()
+            ->setDefaultByRestBusinessOnBehalfRequest($restBusinessOnBehalfRequestTransfer);
+    }
+}

--- a/bundles/business-on-behalf-rest-api/src/FondOfOryx/Zed/BusinessOnBehalfRestApi/Business/Reader/CompanyUserReader.php
+++ b/bundles/business-on-behalf-rest-api/src/FondOfOryx/Zed/BusinessOnBehalfRestApi/Business/Reader/CompanyUserReader.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\Reader;
+
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToCompanyUserFacadeInterface;
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\Persistence\BusinessOnBehalfRestApiRepositoryInterface;
+use Generated\Shared\Transfer\CompanyUserTransfer;
+use Generated\Shared\Transfer\RestBusinessOnBehalfRequestTransfer;
+
+class CompanyUserReader implements CompanyUserReaderInterface
+{
+    /**
+     * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToCompanyUserFacadeInterface
+     */
+    protected BusinessOnBehalfRestApiToCompanyUserFacadeInterface $companyUserFacade;
+
+    /**
+     * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Persistence\BusinessOnBehalfRestApiRepositoryInterface
+     */
+    protected BusinessOnBehalfRestApiRepositoryInterface $repository;
+
+    /**
+     * @param \FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToCompanyUserFacadeInterface $companyUserFacade
+     * @param \FondOfOryx\Zed\BusinessOnBehalfRestApi\Persistence\BusinessOnBehalfRestApiRepositoryInterface $repository
+     */
+    public function __construct(
+        BusinessOnBehalfRestApiToCompanyUserFacadeInterface $companyUserFacade,
+        BusinessOnBehalfRestApiRepositoryInterface $repository
+    ) {
+        $this->companyUserFacade = $companyUserFacade;
+        $this->repository = $repository;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\RestBusinessOnBehalfRequestTransfer $restBusinessOnBehalfRequestTransfer
+     *
+     * @return \Generated\Shared\Transfer\CompanyUserTransfer|null
+     */
+    public function getByRestBusinessOnBehalfRequest(
+        RestBusinessOnBehalfRequestTransfer $restBusinessOnBehalfRequestTransfer
+    ): ?CompanyUserTransfer {
+        $idCustomer = $restBusinessOnBehalfRequestTransfer->getIdCustomer();
+        $companyUserReference = $restBusinessOnBehalfRequestTransfer->getCompanyUserReference();
+
+        if ($idCustomer === null || $companyUserReference === null) {
+            return null;
+        }
+
+        $idCompanyUser = $this->repository->getIdCompanyUserByIdCustomerAndCompanyUserReference(
+            $idCustomer,
+            $companyUserReference,
+        );
+
+        if ($idCompanyUser === null) {
+            return null;
+        }
+
+        return $this->companyUserFacade->getCompanyUserById($idCompanyUser);
+    }
+}

--- a/bundles/business-on-behalf-rest-api/src/FondOfOryx/Zed/BusinessOnBehalfRestApi/Business/Writer/CompanyUserWriter.php
+++ b/bundles/business-on-behalf-rest-api/src/FondOfOryx/Zed/BusinessOnBehalfRestApi/Business/Writer/CompanyUserWriter.php
@@ -55,6 +55,17 @@ class CompanyUserWriter implements CompanyUserWriterInterface
                 ->addError($restBusinessOnBehalfErrorTransfer);
         }
 
+        $customerTransfer = $companyUserTransfer->getCustomer();
+
+        if ($customerTransfer === null) {
+            $restBusinessOnBehalfErrorTransfer = (new RestBusinessOnBehalfErrorTransfer())
+                ->setMessage(BusinessOnBehalfRestApiConstants::ERROR_MESSAGE_INVALID_COMPANY_USER)
+                ->setErrorCode(BusinessOnBehalfRestApiConstants::ERROR_CODE_INVALID_COMPANY_USER);
+
+            return $restBusinessOnBehalfResponseTransfer->setIsSuccessful(false)
+                ->addError($restBusinessOnBehalfErrorTransfer);
+        }
+
         $this->businessOnBehalfFacade->unsetDefaultCompanyUserByCustomer($companyUserTransfer->getCustomer());
         $this->businessOnBehalfFacade->setDefaultCompanyUser($companyUserTransfer);
 

--- a/bundles/business-on-behalf-rest-api/src/FondOfOryx/Zed/BusinessOnBehalfRestApi/Business/Writer/CompanyUserWriter.php
+++ b/bundles/business-on-behalf-rest-api/src/FondOfOryx/Zed/BusinessOnBehalfRestApi/Business/Writer/CompanyUserWriter.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\Writer;
+
+use FondOfOryx\Shared\BusinessOnBehalfRestApi\BusinessOnBehalfRestApiConstants;
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\Reader\CompanyUserReaderInterface;
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToBusinessOnBehalfFacadeInterface;
+use Generated\Shared\Transfer\RestBusinessOnBehalfErrorTransfer;
+use Generated\Shared\Transfer\RestBusinessOnBehalfRequestTransfer;
+use Generated\Shared\Transfer\RestBusinessOnBehalfResponseTransfer;
+
+class CompanyUserWriter implements CompanyUserWriterInterface
+{
+    /**
+     * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\Reader\CompanyUserReaderInterface
+     */
+    protected CompanyUserReaderInterface $companyUserReader;
+
+    /**
+     * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToBusinessOnBehalfFacadeInterface
+     */
+    protected BusinessOnBehalfRestApiToBusinessOnBehalfFacadeInterface $businessOnBehalfFacade;
+
+    /**
+     * @param \FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\Reader\CompanyUserReaderInterface $companyUserReader
+     * @param \FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToBusinessOnBehalfFacadeInterface $businessOnBehalfFacade
+     */
+    public function __construct(
+        CompanyUserReaderInterface $companyUserReader,
+        BusinessOnBehalfRestApiToBusinessOnBehalfFacadeInterface $businessOnBehalfFacade
+    ) {
+        $this->companyUserReader = $companyUserReader;
+        $this->businessOnBehalfFacade = $businessOnBehalfFacade;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\RestBusinessOnBehalfRequestTransfer $restBusinessOnBehalfRequestTransfer
+     *
+     * @return \Generated\Shared\Transfer\RestBusinessOnBehalfResponseTransfer
+     */
+    public function setDefaultByRestBusinessOnBehalfRequest(
+        RestBusinessOnBehalfRequestTransfer $restBusinessOnBehalfRequestTransfer
+    ): RestBusinessOnBehalfResponseTransfer {
+        $restBusinessOnBehalfResponseTransfer = (new RestBusinessOnBehalfResponseTransfer())->setIsSuccessful(true);
+        $companyUserTransfer = $this->companyUserReader->getByRestBusinessOnBehalfRequest(
+            $restBusinessOnBehalfRequestTransfer,
+        );
+
+        if ($companyUserTransfer === null) {
+            $restBusinessOnBehalfErrorTransfer = (new RestBusinessOnBehalfErrorTransfer())
+                ->setMessage(BusinessOnBehalfRestApiConstants::ERROR_MESSAGE_COMPANY_USER_NOT_FOUND)
+                ->setErrorCode(BusinessOnBehalfRestApiConstants::ERROR_CODE_COMPANY_USER_NOT_FOUND);
+
+            return $restBusinessOnBehalfResponseTransfer->setIsSuccessful(false)
+                ->addError($restBusinessOnBehalfErrorTransfer);
+        }
+
+        $this->businessOnBehalfFacade->unsetDefaultCompanyUserByCustomer($companyUserTransfer->getCustomer());
+        $this->businessOnBehalfFacade->setDefaultCompanyUser($companyUserTransfer);
+
+        return $restBusinessOnBehalfResponseTransfer;
+    }
+}

--- a/bundles/business-on-behalf-rest-api/src/FondOfOryx/Zed/BusinessOnBehalfRestApi/BusinessOnBehalfRestApiDependencyProvider.php
+++ b/bundles/business-on-behalf-rest-api/src/FondOfOryx/Zed/BusinessOnBehalfRestApi/BusinessOnBehalfRestApiDependencyProvider.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace FondOfOryx\Zed\BusinessOnBehalfRestApi;
+
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToBusinessOnBehalfFacadeBridge;
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToCompanyUserFacadeBridge;
+use Orm\Zed\CompanyUser\Persistence\Base\SpyCompanyUserQuery;
+use Spryker\Zed\Kernel\AbstractBundleDependencyProvider;
+use Spryker\Zed\Kernel\Container;
+
+class BusinessOnBehalfRestApiDependencyProvider extends AbstractBundleDependencyProvider
+{
+    /**
+     * @var string
+     */
+    public const FACADE_COMPANY_USER = 'FACADE_COMPANY_USER';
+
+    /**
+     * @var string
+     */
+    public const FACADE_BUSINESS_ON_BEHALF = 'FACADE_BUSINESS_ON_BEHALF';
+
+    /**
+     * @var string
+     */
+    public const PROPEL_QUERY_COMPANY_USER = 'PROPEL_QUERY_COMPANY_USER';
+
+    /**
+     * @param \Spryker\Zed\Kernel\Container $container
+     *
+     * @return \Spryker\Zed\Kernel\Container
+     */
+    public function provideBusinessLayerDependencies(Container $container): Container
+    {
+        $container = parent::provideBusinessLayerDependencies($container);
+
+        $container = $this->addBusinessOnBehalfFacade($container);
+
+        return $this->addCompanyUserFacade($container);
+    }
+
+    /**
+     * @param \Spryker\Zed\Kernel\Container $container
+     *
+     * @return \Spryker\Zed\Kernel\Container
+     */
+    public function providePersistenceLayerDependencies(Container $container): Container
+    {
+        $container = parent::providePersistenceLayerDependencies($container);
+
+        return $this->addCompanyUserQuery($container);
+    }
+
+    /**
+     * @param \Spryker\Zed\Kernel\Container $container
+     *
+     * @return \Spryker\Zed\Kernel\Container
+     */
+    protected function addBusinessOnBehalfFacade(Container $container): Container
+    {
+        $container[static::FACADE_BUSINESS_ON_BEHALF] = static fn (
+            Container $container
+        ) => new BusinessOnBehalfRestApiToBusinessOnBehalfFacadeBridge(
+            $container->getLocator()->businessOnBehalf()->facade(),
+        );
+
+        return $container;
+    }
+
+    /**
+     * @param \Spryker\Zed\Kernel\Container $container
+     *
+     * @return \Spryker\Zed\Kernel\Container
+     */
+    protected function addCompanyUserFacade(Container $container): Container
+    {
+        $container[static::FACADE_COMPANY_USER] = static fn (
+            Container $container
+        ) => new BusinessOnBehalfRestApiToCompanyUserFacadeBridge(
+            $container->getLocator()->companyUser()->facade(),
+        );
+
+        return $container;
+    }
+
+    /**
+     * @param \Spryker\Zed\Kernel\Container $container
+     *
+     * @return \Spryker\Zed\Kernel\Container
+     */
+    protected function addCompanyUserQuery(Container $container): Container
+    {
+        $container[static::PROPEL_QUERY_COMPANY_USER] = static fn () => SpyCompanyUserQuery::create();
+
+        return $container;
+    }
+}

--- a/bundles/business-on-behalf-rest-api/src/FondOfOryx/Zed/BusinessOnBehalfRestApi/BusinessOnBehalfRestApiDependencyProvider.php
+++ b/bundles/business-on-behalf-rest-api/src/FondOfOryx/Zed/BusinessOnBehalfRestApi/BusinessOnBehalfRestApiDependencyProvider.php
@@ -40,6 +40,8 @@ class BusinessOnBehalfRestApiDependencyProvider extends AbstractBundleDependency
     }
 
     /**
+     * @codeCoverageIgnore
+     *
      * @param \Spryker\Zed\Kernel\Container $container
      *
      * @return \Spryker\Zed\Kernel\Container
@@ -84,6 +86,8 @@ class BusinessOnBehalfRestApiDependencyProvider extends AbstractBundleDependency
     }
 
     /**
+     * @codeCoverageIgnore
+     *
      * @param \Spryker\Zed\Kernel\Container $container
      *
      * @return \Spryker\Zed\Kernel\Container

--- a/bundles/business-on-behalf-rest-api/src/FondOfOryx/Zed/BusinessOnBehalfRestApi/Communication/Controller/GatewayController.php
+++ b/bundles/business-on-behalf-rest-api/src/FondOfOryx/Zed/BusinessOnBehalfRestApi/Communication/Controller/GatewayController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace FondOfOryx\Zed\BusinessOnBehalfRestApi\Communication\Controller;
+
+use Generated\Shared\Transfer\RestBusinessOnBehalfRequestTransfer;
+use Generated\Shared\Transfer\RestBusinessOnBehalfResponseTransfer;
+use Spryker\Zed\Kernel\Communication\Controller\AbstractGatewayController;
+
+/**
+ * @method \FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\BusinessOnBehalfRestApiFacadeInterface getFacade()
+ */
+class GatewayController extends AbstractGatewayController
+{
+    /**
+     * @param \Generated\Shared\Transfer\RestBusinessOnBehalfRequestTransfer $restBusinessOnBehalfRequestTransfer
+     *
+     * @return \Generated\Shared\Transfer\RestBusinessOnBehalfResponseTransfer
+     */
+    public function setDefaultCompanyUserByRestBusinessOnBehalfRequestAction(
+        RestBusinessOnBehalfRequestTransfer $restBusinessOnBehalfRequestTransfer
+    ): RestBusinessOnBehalfResponseTransfer {
+        return $this->getFacade()->setDefaultCompanyUserByRestBusinessOnBehalfRequest(
+            $restBusinessOnBehalfRequestTransfer,
+        );
+    }
+}

--- a/bundles/business-on-behalf-rest-api/src/FondOfOryx/Zed/BusinessOnBehalfRestApi/Dependency/Facade/BusinessOnBehalfRestApiToBusinessOnBehalfFacadeBridge.php
+++ b/bundles/business-on-behalf-rest-api/src/FondOfOryx/Zed/BusinessOnBehalfRestApi/Dependency/Facade/BusinessOnBehalfRestApiToBusinessOnBehalfFacadeBridge.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade;
+
+use Generated\Shared\Transfer\CompanyUserResponseTransfer;
+use Generated\Shared\Transfer\CompanyUserTransfer;
+use Generated\Shared\Transfer\CustomerTransfer;
+use Spryker\Zed\BusinessOnBehalf\Business\BusinessOnBehalfFacadeInterface;
+
+class BusinessOnBehalfRestApiToBusinessOnBehalfFacadeBridge implements BusinessOnBehalfRestApiToBusinessOnBehalfFacadeInterface
+{
+    /**
+     * @var \Spryker\Zed\BusinessOnBehalf\Business\BusinessOnBehalfFacadeInterface
+     */
+    protected BusinessOnBehalfFacadeInterface $businessOnBehalfFacade;
+
+    /**
+     * @param \Spryker\Zed\BusinessOnBehalf\Business\BusinessOnBehalfFacadeInterface $businessOnBehalfFacade
+     */
+    public function __construct(BusinessOnBehalfFacadeInterface $businessOnBehalfFacade)
+    {
+        $this->businessOnBehalfFacade = $businessOnBehalfFacade;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\CompanyUserTransfer $companyUserTransfer
+     *
+     * @return \Generated\Shared\Transfer\CompanyUserResponseTransfer
+     */
+    public function setDefaultCompanyUser(CompanyUserTransfer $companyUserTransfer): CompanyUserResponseTransfer
+    {
+        return $this->businessOnBehalfFacade->setDefaultCompanyUser($companyUserTransfer);
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\CustomerTransfer $customerTransfer
+     *
+     * @return \Generated\Shared\Transfer\CustomerTransfer
+     */
+    public function unsetDefaultCompanyUserByCustomer(CustomerTransfer $customerTransfer): CustomerTransfer
+    {
+        return $this->businessOnBehalfFacade->unsetDefaultCompanyUserByCustomer($customerTransfer);
+    }
+}

--- a/bundles/business-on-behalf-rest-api/src/FondOfOryx/Zed/BusinessOnBehalfRestApi/Dependency/Facade/BusinessOnBehalfRestApiToCompanyUserFacadeBridge.php
+++ b/bundles/business-on-behalf-rest-api/src/FondOfOryx/Zed/BusinessOnBehalfRestApi/Dependency/Facade/BusinessOnBehalfRestApiToCompanyUserFacadeBridge.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade;
+
+use Generated\Shared\Transfer\CompanyUserTransfer;
+use Spryker\Zed\CompanyUser\Business\CompanyUserFacadeInterface;
+
+class BusinessOnBehalfRestApiToCompanyUserFacadeBridge implements BusinessOnBehalfRestApiToCompanyUserFacadeInterface
+{
+    /**
+     * @var \Spryker\Zed\CompanyUser\Business\CompanyUserFacadeInterface
+     */
+    protected CompanyUserFacadeInterface $companyUserFacade;
+
+    /**
+     * @param \Spryker\Zed\CompanyUser\Business\CompanyUserFacadeInterface $companyUserFacade
+     */
+    public function __construct(CompanyUserFacadeInterface $companyUserFacade)
+    {
+        $this->companyUserFacade = $companyUserFacade;
+    }
+
+    /**
+     * @param int $idCompanyUser
+     *
+     * @return \Generated\Shared\Transfer\CompanyUserTransfer
+     */
+    public function getCompanyUserById(int $idCompanyUser): CompanyUserTransfer
+    {
+        return $this->companyUserFacade->getCompanyUserById($idCompanyUser);
+    }
+}

--- a/bundles/business-on-behalf-rest-api/src/FondOfOryx/Zed/BusinessOnBehalfRestApi/Persistence/BusinessOnBehalfRestApiPersistenceFactory.php
+++ b/bundles/business-on-behalf-rest-api/src/FondOfOryx/Zed/BusinessOnBehalfRestApi/Persistence/BusinessOnBehalfRestApiPersistenceFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace FondOfOryx\Zed\BusinessOnBehalfRestApi\Persistence;
+
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\BusinessOnBehalfRestApiDependencyProvider;
+use Orm\Zed\CompanyUser\Persistence\Base\SpyCompanyUserQuery;
+use Spryker\Zed\Kernel\Persistence\AbstractPersistenceFactory;
+
+/**
+ * @codeCoverageIgnore
+ */
+class BusinessOnBehalfRestApiPersistenceFactory extends AbstractPersistenceFactory
+{
+    /**
+     * @return \Orm\Zed\CompanyUser\Persistence\Base\SpyCompanyUserQuery
+     */
+    public function getCompanyUserQuery(): SpyCompanyUserQuery
+    {
+        return $this->getProvidedDependency(BusinessOnBehalfRestApiDependencyProvider::PROPEL_QUERY_COMPANY_USER);
+    }
+}

--- a/bundles/business-on-behalf-rest-api/src/FondOfOryx/Zed/BusinessOnBehalfRestApi/Persistence/BusinessOnBehalfRestApiRepository.php
+++ b/bundles/business-on-behalf-rest-api/src/FondOfOryx/Zed/BusinessOnBehalfRestApi/Persistence/BusinessOnBehalfRestApiRepository.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace FondOfOryx\Zed\BusinessOnBehalfRestApi\Persistence;
+
+use Orm\Zed\CompanyUser\Persistence\Map\SpyCompanyUserTableMap;
+use Spryker\Zed\Kernel\Persistence\AbstractRepository;
+
+/**
+ * @codeCoverageIgnore
+ *
+ * @method \FondOfOryx\Zed\BusinessOnBehalfRestApi\Persistence\BusinessOnBehalfRestApiPersistenceFactory getFactory()
+ */
+class BusinessOnBehalfRestApiRepository extends AbstractRepository implements BusinessOnBehalfRestApiRepositoryInterface
+{
+    /**
+     * @param int $idCustomer
+     * @param string $companyUserReference
+     *
+     * @return int|null
+     */
+    public function getIdCompanyUserByIdCustomerAndCompanyUserReference(
+        int $idCustomer,
+        string $companyUserReference
+    ): ?int {
+        /** @var int|null $idCompanyUser */
+        $idCompanyUser = $this->getFactory()->getCompanyUserQuery()
+            ->clear()
+            ->filterByFkCustomer($idCustomer)
+            ->filterByCompanyUserReference($companyUserReference)
+            ->select([SpyCompanyUserTableMap::COL_ID_COMPANY_USER])
+            ->findOne();
+
+        return $idCompanyUser;
+    }
+}

--- a/bundles/business-on-behalf-rest-api/tests/FondOfOryx/Zed/BusinessOnBehalfRestApi/Business/BusinessOnBehalfRestApiBusinessFactoryTest.php
+++ b/bundles/business-on-behalf-rest-api/tests/FondOfOryx/Zed/BusinessOnBehalfRestApi/Business/BusinessOnBehalfRestApiBusinessFactoryTest.php
@@ -3,11 +3,13 @@
 namespace FondOfOryx\Zed\BusinessOnBehalfRestApi\Business;
 
 use Codeception\Test\Unit;
-use FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\Writer\CompanyUserWriterInterface;
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\Writer\CompanyUserWriter;
 use FondOfOryx\Zed\BusinessOnBehalfRestApi\BusinessOnBehalfRestApiDependencyProvider;
 use FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToBusinessOnBehalfFacadeInterface;
 use FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToCompanyUserFacadeInterface;
 use FondOfOryx\Zed\BusinessOnBehalfRestApi\Persistence\BusinessOnBehalfRestApiRepository;
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\Persistence\BusinessOnBehalfRestApiRepositoryInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use Spryker\Zed\Kernel\Container;
 
 class BusinessOnBehalfRestApiBusinessFactoryTest extends Unit
@@ -15,27 +17,27 @@ class BusinessOnBehalfRestApiBusinessFactoryTest extends Unit
     /**
      * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToBusinessOnBehalfFacadeInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected $businessOnBehalfFacadeMock;
+    protected MockObject|BusinessOnBehalfRestApiToBusinessOnBehalfFacadeInterface $businessOnBehalfFacadeMock;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\Kernel\Container|mixed
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\Kernel\Container
      */
-    protected $containerMock;
+    protected MockObject|Container $containerMock;
 
     /**
      * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToCompanyUserFacadeInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected $companyUserFacadeMock;
+    protected BusinessOnBehalfRestApiToCompanyUserFacadeInterface|MockObject $companyUserFacadeMock;
 
     /**
      * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Persistence\BusinessOnBehalfRestApiRepositoryInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected $repositoryMock;
+    protected MockObject|BusinessOnBehalfRestApiRepositoryInterface $repositoryMock;
 
     /**
      * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\BusinessOnBehalfRestApiBusinessFactory
      */
-    protected $businessFactory;
+    protected BusinessOnBehalfRestApiBusinessFactory $businessFactory;
 
     /**
      * @return void
@@ -90,7 +92,7 @@ class BusinessOnBehalfRestApiBusinessFactoryTest extends Unit
             );
 
         static::assertInstanceOf(
-            CompanyUserWriterInterface::class,
+            CompanyUserWriter::class,
             $this->businessFactory->createCompanyUserWriter(),
         );
     }

--- a/bundles/business-on-behalf-rest-api/tests/FondOfOryx/Zed/BusinessOnBehalfRestApi/Business/BusinessOnBehalfRestApiBusinessFactoryTest.php
+++ b/bundles/business-on-behalf-rest-api/tests/FondOfOryx/Zed/BusinessOnBehalfRestApi/Business/BusinessOnBehalfRestApiBusinessFactoryTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace FondOfOryx\Zed\BusinessOnBehalfRestApi\Business;
+
+use Codeception\Test\Unit;
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\Writer\CompanyUserWriterInterface;
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\BusinessOnBehalfRestApiDependencyProvider;
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToBusinessOnBehalfFacadeInterface;
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToCompanyUserFacadeInterface;
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\Persistence\BusinessOnBehalfRestApiRepository;
+use Spryker\Zed\Kernel\Container;
+
+class BusinessOnBehalfRestApiBusinessFactoryTest extends Unit
+{
+    /**
+     * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToBusinessOnBehalfFacadeInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $businessOnBehalfFacadeMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\Kernel\Container|mixed
+     */
+    protected $containerMock;
+
+    /**
+     * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToCompanyUserFacadeInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $companyUserFacadeMock;
+
+    /**
+     * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Persistence\BusinessOnBehalfRestApiRepositoryInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $repositoryMock;
+
+    /**
+     * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\BusinessOnBehalfRestApiBusinessFactory
+     */
+    protected $businessFactory;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        parent::_before();
+
+        $this->containerMock = $this->getMockBuilder(Container::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companyUserFacadeMock = $this->getMockBuilder(BusinessOnBehalfRestApiToCompanyUserFacadeInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->businessOnBehalfFacadeMock = $this->getMockBuilder(BusinessOnBehalfRestApiToBusinessOnBehalfFacadeInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->repositoryMock = $this->getMockBuilder(BusinessOnBehalfRestApiRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->businessFactory = new BusinessOnBehalfRestApiBusinessFactory();
+        $this->businessFactory->setRepository($this->repositoryMock);
+        $this->businessFactory->setContainer($this->containerMock);
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreateCompanyUserWriter(): void
+    {
+        $this->containerMock->expects(static::atLeastOnce())
+            ->method('has')
+            ->withConsecutive(
+                [BusinessOnBehalfRestApiDependencyProvider::FACADE_COMPANY_USER],
+                [BusinessOnBehalfRestApiDependencyProvider::FACADE_BUSINESS_ON_BEHALF],
+            )
+            ->willReturn(true);
+
+        $this->containerMock->expects(static::atLeastOnce())
+            ->method('get')
+            ->withConsecutive(
+                [BusinessOnBehalfRestApiDependencyProvider::FACADE_COMPANY_USER],
+                [BusinessOnBehalfRestApiDependencyProvider::FACADE_BUSINESS_ON_BEHALF],
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->companyUserFacadeMock,
+                $this->businessOnBehalfFacadeMock,
+            );
+
+        static::assertInstanceOf(
+            CompanyUserWriterInterface::class,
+            $this->businessFactory->createCompanyUserWriter(),
+        );
+    }
+}

--- a/bundles/business-on-behalf-rest-api/tests/FondOfOryx/Zed/BusinessOnBehalfRestApi/Business/BusinessOnBehalfRestApiFacadeTest.php
+++ b/bundles/business-on-behalf-rest-api/tests/FondOfOryx/Zed/BusinessOnBehalfRestApi/Business/BusinessOnBehalfRestApiFacadeTest.php
@@ -3,37 +3,37 @@
 namespace FondOfOryx\Zed\BusinessOnBehalfRestApi\Business;
 
 use Codeception\Test\Unit;
-use FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\BusinessOnBehalfRestApiBusinessFactory;
 use FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\Writer\CompanyUserWriterInterface;
 use Generated\Shared\Transfer\RestBusinessOnBehalfRequestTransfer;
 use Generated\Shared\Transfer\RestBusinessOnBehalfResponseTransfer;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class BusinessOnBehalfRestApiFacadeTest extends Unit
 {
     /**
      * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\BusinessOnBehalfRestApiBusinessFactory|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected $factoryMock;
+    protected MockObject|BusinessOnBehalfRestApiBusinessFactory $factoryMock;
 
     /**
      * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\Writer\CompanyUserWriterInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected $companyUserWritterMock;
+    protected MockObject|CompanyUserWriterInterface $companyUserWriterMock;
 
     /**
-     * @var \Generated\Shared\Transfer\RestBusinessOnBehalfRequestTransfer|\PHPUnit\Framework\MockObject\MockObject|mixed
+     * @var \Generated\Shared\Transfer\RestBusinessOnBehalfRequestTransfer|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected $restBusinessOnBehalfRequestTransferMock;
+    protected RestBusinessOnBehalfRequestTransfer|MockObject $restBusinessOnBehalfRequestTransferMock;
 
     /**
-     * @var \Generated\Shared\Transfer\RestBusinessOnBehalfResponseTransfer|\PHPUnit\Framework\MockObject\MockObject|mixed
+     * @var \Generated\Shared\Transfer\RestBusinessOnBehalfResponseTransfer|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected $restBusinessOnBehalfResponseTransferMock;
+    protected RestBusinessOnBehalfResponseTransfer|MockObject $restBusinessOnBehalfResponseTransferMock;
 
     /**
      * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\BusinessOnBehalfRestApiFacade
      */
-    protected $facade;
+    protected BusinessOnBehalfRestApiFacade $facade;
 
     /**
      * @return void
@@ -46,22 +46,15 @@ class BusinessOnBehalfRestApiFacadeTest extends Unit
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->companyUserWritterMock = $this->getMockBuilder(CompanyUserWriterInterface::class)
+        $this->companyUserWriterMock = $this->getMockBuilder(CompanyUserWriterInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->restBusinessOnBehalfRequestTransferMock = $this
-            ->getMockBuilder(RestBusinessOnBehalfRequestTransfer::class)
+        $this->restBusinessOnBehalfRequestTransferMock = $this->getMockBuilder(RestBusinessOnBehalfRequestTransfer::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->restBusinessOnBehalfRequestTransferMock = $this
-            ->getMockBuilder(RestBusinessOnBehalfRequestTransfer::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->restBusinessOnBehalfResponseTransferMock = $this
-            ->getMockBuilder(RestBusinessOnBehalfResponseTransfer::class)
+        $this->restBusinessOnBehalfResponseTransferMock = $this->getMockBuilder(RestBusinessOnBehalfResponseTransfer::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -76,16 +69,18 @@ class BusinessOnBehalfRestApiFacadeTest extends Unit
     {
         $this->factoryMock->expects(static::atLeastOnce())
             ->method('createCompanyUserWriter')
-            ->willReturn($this->companyUserWritterMock);
+            ->willReturn($this->companyUserWriterMock);
 
-        $this->companyUserWritterMock->expects(static::atLeastOnce())
+        $this->companyUserWriterMock->expects(static::atLeastOnce())
             ->method('setDefaultByRestBusinessOnBehalfRequest')
             ->with($this->restBusinessOnBehalfRequestTransferMock)
             ->willReturn($this->restBusinessOnBehalfResponseTransferMock);
 
         static::assertEquals(
             $this->restBusinessOnBehalfResponseTransferMock,
-            $this->facade->setDefaultCompanyUserByRestBusinessOnBehalfRequest($this->restBusinessOnBehalfRequestTransferMock),
+            $this->facade->setDefaultCompanyUserByRestBusinessOnBehalfRequest(
+                $this->restBusinessOnBehalfRequestTransferMock,
+            ),
         );
     }
 }

--- a/bundles/business-on-behalf-rest-api/tests/FondOfOryx/Zed/BusinessOnBehalfRestApi/Business/BusinessOnBehalfRestApiFacadeTest.php
+++ b/bundles/business-on-behalf-rest-api/tests/FondOfOryx/Zed/BusinessOnBehalfRestApi/Business/BusinessOnBehalfRestApiFacadeTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace FondOfOryx\Zed\BusinessOnBehalfRestApi\Business;
+
+use Codeception\Test\Unit;
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\BusinessOnBehalfRestApiBusinessFactory;
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\Writer\CompanyUserWriterInterface;
+use Generated\Shared\Transfer\RestBusinessOnBehalfRequestTransfer;
+use Generated\Shared\Transfer\RestBusinessOnBehalfResponseTransfer;
+
+class BusinessOnBehalfRestApiFacadeTest extends Unit
+{
+    /**
+     * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\BusinessOnBehalfRestApiBusinessFactory|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $factoryMock;
+
+    /**
+     * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\Writer\CompanyUserWriterInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $companyUserWritterMock;
+
+    /**
+     * @var \Generated\Shared\Transfer\RestBusinessOnBehalfRequestTransfer|\PHPUnit\Framework\MockObject\MockObject|mixed
+     */
+    protected $restBusinessOnBehalfRequestTransferMock;
+
+    /**
+     * @var \Generated\Shared\Transfer\RestBusinessOnBehalfResponseTransfer|\PHPUnit\Framework\MockObject\MockObject|mixed
+     */
+    protected $restBusinessOnBehalfResponseTransferMock;
+
+    /**
+     * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\BusinessOnBehalfRestApiFacade
+     */
+    protected $facade;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        parent::_before();
+
+        $this->factoryMock = $this->getMockBuilder(BusinessOnBehalfRestApiBusinessFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companyUserWritterMock = $this->getMockBuilder(CompanyUserWriterInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->restBusinessOnBehalfRequestTransferMock = $this
+            ->getMockBuilder(RestBusinessOnBehalfRequestTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->restBusinessOnBehalfRequestTransferMock = $this
+            ->getMockBuilder(RestBusinessOnBehalfRequestTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->restBusinessOnBehalfResponseTransferMock = $this
+            ->getMockBuilder(RestBusinessOnBehalfResponseTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->facade = new BusinessOnBehalfRestApiFacade();
+        $this->facade->setFactory($this->factoryMock);
+    }
+
+    /**
+     * @return void
+     */
+    public function testSetDefaultCompanyUserByRestBusinessOnBehalfRequest(): void
+    {
+        $this->factoryMock->expects(static::atLeastOnce())
+            ->method('createCompanyUserWriter')
+            ->willReturn($this->companyUserWritterMock);
+
+        $this->companyUserWritterMock->expects(static::atLeastOnce())
+            ->method('setDefaultByRestBusinessOnBehalfRequest')
+            ->with($this->restBusinessOnBehalfRequestTransferMock)
+            ->willReturn($this->restBusinessOnBehalfResponseTransferMock);
+
+        static::assertEquals(
+            $this->restBusinessOnBehalfResponseTransferMock,
+            $this->facade->setDefaultCompanyUserByRestBusinessOnBehalfRequest($this->restBusinessOnBehalfRequestTransferMock),
+        );
+    }
+}

--- a/bundles/business-on-behalf-rest-api/tests/FondOfOryx/Zed/BusinessOnBehalfRestApi/Business/Reader/CompanyUserReaderTest.php
+++ b/bundles/business-on-behalf-rest-api/tests/FondOfOryx/Zed/BusinessOnBehalfRestApi/Business/Reader/CompanyUserReaderTest.php
@@ -7,33 +7,34 @@ use FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRes
 use FondOfOryx\Zed\BusinessOnBehalfRestApi\Persistence\BusinessOnBehalfRestApiRepositoryInterface;
 use Generated\Shared\Transfer\CompanyUserTransfer;
 use Generated\Shared\Transfer\RestBusinessOnBehalfRequestTransfer;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class CompanyUserReaderTest extends Unit
 {
     /**
-     * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\Reader\CompanyUserReaderInterface
+     * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Persistence\BusinessOnBehalfRestApiRepositoryInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected $companyUserReader;
-
-    /**
-     * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Persistence\BusinessOnBehalfRestApiRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject)|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected $repositoryMock;
+    protected MockObject|BusinessOnBehalfRestApiRepositoryInterface $repositoryMock;
 
     /**
      * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToCompanyUserFacadeInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected $companyUserFacadeMock;
+    protected BusinessOnBehalfRestApiToCompanyUserFacadeInterface|MockObject $companyUserFacadeMock;
 
     /**
      * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToCompanyUserFacadeInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected $companyUserTransferMock;
+    protected BusinessOnBehalfRestApiToCompanyUserFacadeInterface|MockObject $companyUserTransferMock;
 
     /**
      * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToCompanyUserFacadeInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected $restBusinessOnBehalfRequestTransfer;
+    protected BusinessOnBehalfRestApiToCompanyUserFacadeInterface|MockObject $restBusinessOnBehalfRequestTransfer;
+
+    /**
+     * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\Reader\CompanyUserReader
+     */
+    protected CompanyUserReader $companyUserReader;
 
     /**
      * @return void

--- a/bundles/business-on-behalf-rest-api/tests/FondOfOryx/Zed/BusinessOnBehalfRestApi/Business/Reader/CompanyUserReaderTest.php
+++ b/bundles/business-on-behalf-rest-api/tests/FondOfOryx/Zed/BusinessOnBehalfRestApi/Business/Reader/CompanyUserReaderTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\Reader;
+
+use Codeception\Test\Unit;
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToCompanyUserFacadeInterface;
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\Persistence\BusinessOnBehalfRestApiRepositoryInterface;
+use Generated\Shared\Transfer\CompanyUserTransfer;
+use Generated\Shared\Transfer\RestBusinessOnBehalfRequestTransfer;
+
+class CompanyUserReaderTest extends Unit
+{
+    /**
+     * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\Reader\CompanyUserReaderInterface
+     */
+    protected $companyUserReader;
+
+    /**
+     * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Persistence\BusinessOnBehalfRestApiRepositoryInterface&\PHPUnit\Framework\MockObject\MockObject)|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $repositoryMock;
+
+    /**
+     * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToCompanyUserFacadeInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $companyUserFacadeMock;
+
+    /**
+     * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToCompanyUserFacadeInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $companyUserTransferMock;
+
+    /**
+     * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToCompanyUserFacadeInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $restBusinessOnBehalfRequestTransfer;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        parent::_before();
+
+        $this->companyUserFacadeMock = $this->getMockBuilder(BusinessOnBehalfRestApiToCompanyUserFacadeInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companyUserTransferMock = $this->getMockBuilder(CompanyUserTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->repositoryMock = $this->getMockBuilder(BusinessOnBehalfRestApiRepositoryInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->restBusinessOnBehalfRequestTransfer = $this->getMockBuilder(RestBusinessOnBehalfRequestTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companyUserReader = new CompanyUserReader(
+            $this->companyUserFacadeMock,
+            $this->repositoryMock,
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetByRestBusinessOnBehalfRequest(): void
+    {
+        $idCustomer = 1;
+        $idCompanyUser = 1;
+        $companyUserReference = 'company-user-reference';
+
+        $this->restBusinessOnBehalfRequestTransfer->expects(static::atLeastOnce())
+            ->method('getIdCustomer')
+            ->willReturn($idCustomer);
+
+        $this->restBusinessOnBehalfRequestTransfer->expects(static::atLeastOnce())
+            ->method('getCompanyUserReference')
+            ->willReturn($companyUserReference);
+
+        $this->repositoryMock->expects(static::atLeastOnce())
+            ->method('getIdCompanyUserByIdCustomerAndCompanyUserReference')
+            ->with($idCustomer, $companyUserReference)
+            ->willReturn($idCompanyUser);
+
+        $this->companyUserFacadeMock->expects(static::atLeastOnce())
+            ->method('getCompanyUserById')
+            ->with($idCompanyUser)
+            ->willReturn($this->companyUserTransferMock);
+
+        static::assertEquals(
+            $this->companyUserTransferMock,
+            $this->companyUserReader->getByRestBusinessOnBehalfRequest($this->restBusinessOnBehalfRequestTransfer),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetByRestBusinessOnBehalfRequestWithInvalidCustomerid(): void
+    {
+        $idCustomer = null;
+        $companyUserReference = 'company-user-reference';
+
+        $this->restBusinessOnBehalfRequestTransfer->expects(static::atLeastOnce())
+            ->method('getIdCustomer')
+            ->willReturn($idCustomer);
+
+        $this->restBusinessOnBehalfRequestTransfer->expects(static::atLeastOnce())
+            ->method('getCompanyUserReference')
+            ->willReturn($companyUserReference);
+
+        static::assertEquals(
+            null,
+            $this->companyUserReader->getByRestBusinessOnBehalfRequest($this->restBusinessOnBehalfRequestTransfer),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetByRestBusinessOnBehalfRequestWithInvalidCompanyUserId(): void
+    {
+        $idCustomer = 1;
+        $companyUserReference = 'company-user-reference';
+
+        $this->restBusinessOnBehalfRequestTransfer->expects(static::atLeastOnce())
+            ->method('getIdCustomer')
+            ->willReturn($idCustomer);
+
+        $this->restBusinessOnBehalfRequestTransfer->expects(static::atLeastOnce())
+            ->method('getCompanyUserReference')
+            ->willReturn($companyUserReference);
+
+        $this->repositoryMock->expects(static::atLeastOnce())
+            ->method('getIdCompanyUserByIdCustomerAndCompanyUserReference')
+            ->with($idCustomer, $companyUserReference)
+            ->willReturn(null);
+
+        static::assertEquals(
+            null,
+            $this->companyUserReader->getByRestBusinessOnBehalfRequest($this->restBusinessOnBehalfRequestTransfer),
+        );
+    }
+}

--- a/bundles/business-on-behalf-rest-api/tests/FondOfOryx/Zed/BusinessOnBehalfRestApi/Business/Writer/CompanyUserWriterTest.php
+++ b/bundles/business-on-behalf-rest-api/tests/FondOfOryx/Zed/BusinessOnBehalfRestApi/Business/Writer/CompanyUserWriterTest.php
@@ -137,7 +137,7 @@ class CompanyUserWriterTest extends Unit
         $restBusinessOnBehalfResponseTransfer = $this->companyUserWriter->setDefaultByRestBusinessOnBehalfRequest(
             $this->restBusinessOnBehalfRequestTransferMock,
         );
-        var_dump($restBusinessOnBehalfResponseTransfer->serialize());
+
         static::assertCount(1, $restBusinessOnBehalfResponseTransfer->getErrors());
         static::assertFalse($restBusinessOnBehalfResponseTransfer->getIsSuccessful());
         static::assertEquals(
@@ -146,6 +146,42 @@ class CompanyUserWriterTest extends Unit
         );
         static::assertEquals(
             BusinessOnBehalfRestApiConstants::ERROR_MESSAGE_COMPANY_USER_NOT_FOUND,
+            $restBusinessOnBehalfResponseTransfer->getErrors()[0]->getMessage(),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testSetDefaultByRestBusinessOnBehalfRequestWithInvalidCompanyUser(): void
+    {
+        $this->companyUserReaderMock->expects(static::atLeastOnce())
+            ->method('getByRestBusinessOnBehalfRequest')
+            ->with($this->restBusinessOnBehalfRequestTransferMock)
+            ->willReturn($this->companyUserTransferMock);
+
+        $this->companyUserTransferMock->expects(static::atLeastOnce())
+            ->method('getCustomer')
+            ->willReturn(null);
+
+        $this->businessOnBehalfFacadeMock->expects(static::never())
+            ->method('unsetDefaultCompanyUserByCustomer');
+
+        $this->businessOnBehalfFacadeMock->expects(static::never())
+            ->method('setDefaultCompanyUser');
+
+        $restBusinessOnBehalfResponseTransfer = $this->companyUserWriter->setDefaultByRestBusinessOnBehalfRequest(
+            $this->restBusinessOnBehalfRequestTransferMock,
+        );
+
+        static::assertCount(1, $restBusinessOnBehalfResponseTransfer->getErrors());
+        static::assertFalse($restBusinessOnBehalfResponseTransfer->getIsSuccessful());
+        static::assertEquals(
+            BusinessOnBehalfRestApiConstants::ERROR_CODE_INVALID_COMPANY_USER,
+            $restBusinessOnBehalfResponseTransfer->getErrors()[0]->getErrorCode(),
+        );
+        static::assertEquals(
+            BusinessOnBehalfRestApiConstants::ERROR_MESSAGE_INVALID_COMPANY_USER,
             $restBusinessOnBehalfResponseTransfer->getErrors()[0]->getMessage(),
         );
     }

--- a/bundles/business-on-behalf-rest-api/tests/FondOfOryx/Zed/BusinessOnBehalfRestApi/Business/Writer/CompanyUserWriterTest.php
+++ b/bundles/business-on-behalf-rest-api/tests/FondOfOryx/Zed/BusinessOnBehalfRestApi/Business/Writer/CompanyUserWriterTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\Writer;
+
+use Codeception\Test\Unit;
+use FondOfOryx\Shared\BusinessOnBehalfRestApi\BusinessOnBehalfRestApiConstants;
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\Reader\CompanyUserReaderInterface;
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToBusinessOnBehalfFacadeInterface;
+use Generated\Shared\Transfer\CompanyUserResponseTransfer;
+use Generated\Shared\Transfer\CompanyUserTransfer;
+use Generated\Shared\Transfer\CustomerTransfer;
+use Generated\Shared\Transfer\RestBusinessOnBehalfRequestTransfer;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class CompanyUserWriterTest extends Unit
+{
+    /**
+     * @var (\FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\Reader\CompanyUserReaderInterface&\PHPUnit\Framework\MockObject\MockObject)|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected CompanyUserReaderInterface|MockObject $companyUserReaderMock;
+
+    /**
+     * @var (\FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToBusinessOnBehalfFacadeInterface&\PHPUnit\Framework\MockObject\MockObject)|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected MockObject|BusinessOnBehalfRestApiToBusinessOnBehalfFacadeInterface $businessOnBehalfFacadeMock;
+
+    /**
+     * @var (\Generated\Shared\Transfer\RestBusinessOnBehalfRequestTransfer&\PHPUnit\Framework\MockObject\MockObject)|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected MockObject|RestBusinessOnBehalfRequestTransfer $restBusinessOnBehalfRequestTransferMock;
+
+    /**
+     * @var (\Generated\Shared\Transfer\CompanyUserTransfer&\PHPUnit\Framework\MockObject\MockObject)|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected CompanyUserTransfer|MockObject $companyUserTransferMock;
+
+    /**
+     * @var (\Generated\Shared\Transfer\CustomerTransfer&\PHPUnit\Framework\MockObject\MockObject)|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected CustomerTransfer|MockObject $customerTransferMock;
+
+    /**
+     * @var (\Generated\Shared\Transfer\CompanyUserResponseTransfer&\PHPUnit\Framework\MockObject\MockObject)|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected CompanyUserResponseTransfer|MockObject $companyUserResponseTransferMock;
+
+    /**
+     * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\Writer\CompanyUserWriter
+     */
+    protected CompanyUserWriter $companyUserWriter;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        parent::_before();
+
+        $this->companyUserReaderMock = $this->getMockBuilder(CompanyUserReaderInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->businessOnBehalfFacadeMock = $this->getMockBuilder(BusinessOnBehalfRestApiToBusinessOnBehalfFacadeInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->restBusinessOnBehalfRequestTransferMock = $this->getMockBuilder(RestBusinessOnBehalfRequestTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companyUserTransferMock = $this->getMockBuilder(CompanyUserTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->customerTransferMock = $this->getMockBuilder(CustomerTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companyUserResponseTransferMock = $this->getMockBuilder(CompanyUserResponseTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companyUserWriter = new CompanyUserWriter(
+            $this->companyUserReaderMock,
+            $this->businessOnBehalfFacadeMock,
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testSetDefaultByRestBusinessOnBehalfRequest(): void
+    {
+        $this->companyUserReaderMock->expects(static::atLeastOnce())
+            ->method('getByRestBusinessOnBehalfRequest')
+            ->with($this->restBusinessOnBehalfRequestTransferMock)
+            ->willReturn($this->companyUserTransferMock);
+
+        $this->companyUserTransferMock->expects(static::atLeastOnce())
+            ->method('getCustomer')
+            ->willReturn($this->customerTransferMock);
+
+        $this->businessOnBehalfFacadeMock->expects(static::atLeastOnce())
+            ->method('unsetDefaultCompanyUserByCustomer')
+            ->with($this->customerTransferMock)
+            ->willReturn($this->customerTransferMock);
+
+        $this->businessOnBehalfFacadeMock->expects(static::atLeastOnce())
+            ->method('setDefaultCompanyUser')
+            ->with($this->companyUserTransferMock)
+            ->willReturn($this->companyUserResponseTransferMock);
+
+        $restBusinessOnBehalfResponseTransfer = $this->companyUserWriter->setDefaultByRestBusinessOnBehalfRequest(
+            $this->restBusinessOnBehalfRequestTransferMock,
+        );
+
+        static::assertEmpty($restBusinessOnBehalfResponseTransfer->getErrors());
+        static::assertTrue($restBusinessOnBehalfResponseTransfer->getIsSuccessful());
+    }
+
+    /**
+     * @return void
+     */
+    public function testSetDefaultByRestBusinessOnBehalfRequestWithoutExistingCompanyUser(): void
+    {
+        $this->companyUserReaderMock->expects(static::atLeastOnce())
+            ->method('getByRestBusinessOnBehalfRequest')
+            ->with($this->restBusinessOnBehalfRequestTransferMock)
+            ->willReturn(null);
+
+        $this->businessOnBehalfFacadeMock->expects(static::never())
+            ->method('unsetDefaultCompanyUserByCustomer');
+
+        $this->businessOnBehalfFacadeMock->expects(static::never())
+            ->method('setDefaultCompanyUser');
+
+        $restBusinessOnBehalfResponseTransfer = $this->companyUserWriter->setDefaultByRestBusinessOnBehalfRequest(
+            $this->restBusinessOnBehalfRequestTransferMock,
+        );
+        var_dump($restBusinessOnBehalfResponseTransfer->serialize());
+        static::assertCount(1, $restBusinessOnBehalfResponseTransfer->getErrors());
+        static::assertFalse($restBusinessOnBehalfResponseTransfer->getIsSuccessful());
+        static::assertEquals(
+            BusinessOnBehalfRestApiConstants::ERROR_CODE_COMPANY_USER_NOT_FOUND,
+            $restBusinessOnBehalfResponseTransfer->getErrors()[0]->getErrorCode(),
+        );
+        static::assertEquals(
+            BusinessOnBehalfRestApiConstants::ERROR_MESSAGE_COMPANY_USER_NOT_FOUND,
+            $restBusinessOnBehalfResponseTransfer->getErrors()[0]->getMessage(),
+        );
+    }
+}

--- a/bundles/business-on-behalf-rest-api/tests/FondOfOryx/Zed/BusinessOnBehalfRestApi/BusinessOnBehalfRestApiDependencyProviderTest.php
+++ b/bundles/business-on-behalf-rest-api/tests/FondOfOryx/Zed/BusinessOnBehalfRestApi/BusinessOnBehalfRestApiDependencyProviderTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace FondOfOryx\Zed\BusinessOnBehalfRestApi;
+
+use Codeception\Test\Unit;
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToBusinessOnBehalfFacadeInterface;
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToCompanyUserFacadeInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use Spryker\Shared\Kernel\BundleProxy;
+use Spryker\Zed\BusinessOnBehalf\Business\BusinessOnBehalfFacadeInterface;
+use Spryker\Zed\CompanyUser\Business\CompanyUserFacadeInterface;
+use Spryker\Zed\Kernel\Container;
+use Spryker\Zed\Kernel\Locator;
+
+class BusinessOnBehalfRestApiDependencyProviderTest extends Unit
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\Kernel\Container
+     */
+    protected MockObject|Container $containerMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\Kernel\Locator
+     */
+    protected MockObject|Locator $locatorMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Shared\Kernel\BundleProxy
+     */
+    protected MockObject|BundleProxy $bundleProxyMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|(\Spryker\Zed\BusinessOnBehalf\Business\BusinessOnBehalfFacadeInterface&\PHPUnit\Framework\MockObject\MockObject)
+     */
+    protected BusinessOnBehalfFacadeInterface|MockObject $businessOnBehalfFacadeMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|(\Spryker\Zed\CompanyUser\Business\CompanyUserFacadeInterface&\PHPUnit\Framework\MockObject\MockObject)
+     */
+    protected CompanyUserFacadeInterface|MockObject $companyUserFacadeMock;
+
+    /**
+     * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\BusinessOnBehalfRestApiDependencyProvider
+     */
+    protected BusinessOnBehalfRestApiDependencyProvider $dependencyProvider;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        parent::_before();
+
+        $this->containerMock = $this->getMockBuilder(Container::class)
+            ->setMethodsExcept(['factory', 'set', 'offsetSet', 'get', 'offsetGet'])
+            ->getMock();
+
+        $this->locatorMock = $this->getMockBuilder(Locator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->bundleProxyMock = $this->getMockBuilder(BundleProxy::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->businessOnBehalfFacadeMock = $this->getMockBuilder(BusinessOnBehalfFacadeInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companyUserFacadeMock = $this->getMockBuilder(CompanyUserFacadeInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->dependencyProvider = new BusinessOnBehalfRestApiDependencyProvider();
+    }
+
+    /**
+     * @return void
+     */
+    public function testProvideBusinessLayerDependencies(): void
+    {
+        $this->containerMock->expects(static::atLeastOnce())
+            ->method('getLocator')
+            ->willReturn($this->locatorMock);
+
+        $this->locatorMock->expects(static::atLeastOnce())
+            ->method('__call')
+            ->withConsecutive(['businessOnBehalf'], ['companyUser'])
+            ->willReturn($this->bundleProxyMock);
+
+        $this->bundleProxyMock->expects(static::atLeastOnce())
+            ->method('__call')
+            ->withConsecutive(['facade'], ['facade'])
+            ->willReturnOnConsecutiveCalls(
+                $this->businessOnBehalfFacadeMock,
+                $this->companyUserFacadeMock,
+            );
+
+        $container = $this->dependencyProvider->provideBusinessLayerDependencies($this->containerMock);
+
+        static::assertEquals($this->containerMock, $container);
+
+        static::assertInstanceOf(
+            BusinessOnBehalfRestApiToBusinessOnBehalfFacadeInterface::class,
+            $container[BusinessOnBehalfRestApiDependencyProvider::FACADE_BUSINESS_ON_BEHALF],
+        );
+
+        static::assertInstanceOf(
+            BusinessOnBehalfRestApiToCompanyUserFacadeInterface::class,
+            $container[BusinessOnBehalfRestApiDependencyProvider::FACADE_COMPANY_USER],
+        );
+    }
+}

--- a/bundles/business-on-behalf-rest-api/tests/FondOfOryx/Zed/BusinessOnBehalfRestApi/Communication/Controller/GatewayControllerTest.php
+++ b/bundles/business-on-behalf-rest-api/tests/FondOfOryx/Zed/BusinessOnBehalfRestApi/Communication/Controller/GatewayControllerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace FondOfOryx\Zed\BusinessOnBehalfRestApi\Communication\Controller;
+
+use Codeception\Test\Unit;
+use FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\BusinessOnBehalfRestApiFacade;
+use Generated\Shared\Transfer\RestBusinessOnBehalfRequestTransfer;
+use Generated\Shared\Transfer\RestBusinessOnBehalfResponseTransfer;
+use PHPUnit\Framework\MockObject\MockObject;
+use Spryker\Zed\Kernel\Business\AbstractFacade;
+
+class GatewayControllerTest extends Unit
+{
+    /**
+     * @var (\FondOfOryx\Zed\BusinessOnBehalfRestApi\Business\BusinessOnBehalfRestApiFacade&\PHPUnit\Framework\MockObject\MockObject)|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected MockObject|BusinessOnBehalfRestApiFacade $facadeMock;
+
+    /**
+     * @var (\Generated\Shared\Transfer\RestBusinessOnBehalfRequestTransfer&\PHPUnit\Framework\MockObject\MockObject)|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected MockObject|RestBusinessOnBehalfRequestTransfer $restBusinessOnBehalfRequestTransferMock;
+
+    /**
+     * @var (\Generated\Shared\Transfer\RestBusinessOnBehalfResponseTransfer&\PHPUnit\Framework\MockObject\MockObject)|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected MockObject|RestBusinessOnBehalfResponseTransfer $restBusinessOnBehalfResponseTransferMock;
+
+    /**
+     * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Communication\Controller\GatewayController
+     */
+    protected GatewayController $gatewayController;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        parent::_before();
+
+        $this->facadeMock = $this->getMockBuilder(BusinessOnBehalfRestApiFacade::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->restBusinessOnBehalfRequestTransferMock = $this->getMockBuilder(RestBusinessOnBehalfRequestTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->restBusinessOnBehalfResponseTransferMock = $this->getMockBuilder(RestBusinessOnBehalfResponseTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->gatewayController = new class ($this->facadeMock) extends GatewayController {
+            /**
+             * @var \Spryker\Zed\Kernel\Business\AbstractFacade
+             */
+            protected AbstractFacade $businessOnBehalfRestApiFacade;
+
+            /**
+             * @param \Spryker\Zed\Kernel\Business\AbstractFacade $businessOnBehalfRestApiFacade
+             */
+            public function __construct(AbstractFacade $businessOnBehalfRestApiFacade)
+            {
+                $this->businessOnBehalfRestApiFacade = $businessOnBehalfRestApiFacade;
+            }
+
+            /**
+             * @return \Spryker\Zed\Kernel\Business\AbstractFacade
+             */
+            protected function getFacade(): AbstractFacade
+            {
+                return $this->businessOnBehalfRestApiFacade;
+            }
+        };
+    }
+
+    /**
+     * @return void
+     */
+    public function testSetDefaultCompanyUserByRestBusinessOnBehalfRequestAction(): void
+    {
+        $this->facadeMock->expects(static::atLeastOnce())
+            ->method('setDefaultCompanyUserByRestBusinessOnBehalfRequest')
+            ->with($this->restBusinessOnBehalfRequestTransferMock)
+            ->willReturn($this->restBusinessOnBehalfResponseTransferMock);
+
+        static::assertEquals(
+            $this->restBusinessOnBehalfResponseTransferMock,
+            $this->gatewayController->setDefaultCompanyUserByRestBusinessOnBehalfRequestAction(
+                $this->restBusinessOnBehalfRequestTransferMock,
+            ),
+        );
+    }
+}

--- a/bundles/business-on-behalf-rest-api/tests/FondOfOryx/Zed/BusinessOnBehalfRestApi/Dependency/Facade/BusinessOnBehalfRestApiToBusinessOnBehalfFacadeBridgeTest.php
+++ b/bundles/business-on-behalf-rest-api/tests/FondOfOryx/Zed/BusinessOnBehalfRestApi/Dependency/Facade/BusinessOnBehalfRestApiToBusinessOnBehalfFacadeBridgeTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade;
+
+use Codeception\Test\Unit;
+use Generated\Shared\Transfer\CompanyUserResponseTransfer;
+use Generated\Shared\Transfer\CompanyUserTransfer;
+use Generated\Shared\Transfer\CustomerTransfer;
+use PHPUnit\Framework\MockObject\MockObject;
+use Spryker\Zed\BusinessOnBehalf\Business\BusinessOnBehalfFacadeInterface;
+
+class BusinessOnBehalfRestApiToBusinessOnBehalfFacadeBridgeTest extends Unit
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|(\Spryker\Zed\BusinessOnBehalf\Business\BusinessOnBehalfFacadeInterface&\PHPUnit\Framework\MockObject\MockObject)
+     */
+    protected BusinessOnBehalfFacadeInterface|MockObject $facadeMock;
+
+    /**
+     * @var (\Generated\Shared\Transfer\CompanyUserTransfer&\PHPUnit\Framework\MockObject\MockObject)|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected CompanyUserTransfer|MockObject $companyUserTransferMock;
+
+    /**
+     * @var (\Generated\Shared\Transfer\CompanyUserResponseTransfer&\PHPUnit\Framework\MockObject\MockObject)|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected MockObject|CompanyUserResponseTransfer $companyUserResponseTransferMock;
+
+    /**
+     * @var (\Generated\Shared\Transfer\CustomerTransfer&\PHPUnit\Framework\MockObject\MockObject)|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected CustomerTransfer|MockObject $customerTransferMock;
+
+    /**
+     * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToBusinessOnBehalfFacadeBridge
+     */
+    protected BusinessOnBehalfRestApiToBusinessOnBehalfFacadeBridge $bridge;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        parent::_before();
+
+        $this->facadeMock = $this->getMockBuilder(BusinessOnBehalfFacadeInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companyUserTransferMock = $this->getMockBuilder(CompanyUserTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companyUserResponseTransferMock = $this->getMockBuilder(CompanyUserResponseTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->customerTransferMock = $this->getMockBuilder(CustomerTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->bridge = new BusinessOnBehalfRestApiToBusinessOnBehalfFacadeBridge(
+            $this->facadeMock,
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testSetDefaultCompanyUser(): void
+    {
+        $this->facadeMock->expects(static::atLeastOnce())
+            ->method('setDefaultCompanyUser')
+            ->with($this->companyUserTransferMock)
+            ->willReturn($this->companyUserResponseTransferMock);
+
+        static::assertEquals(
+            $this->companyUserResponseTransferMock,
+            $this->bridge->setDefaultCompanyUser($this->companyUserTransferMock),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testUnsetDefaultCompanyUserByCustomer(): void
+    {
+        $this->facadeMock->expects(static::atLeastOnce())
+            ->method('unsetDefaultCompanyUserByCustomer')
+            ->with($this->customerTransferMock)
+            ->willReturn($this->customerTransferMock);
+
+        static::assertEquals(
+            $this->customerTransferMock,
+            $this->bridge->unsetDefaultCompanyUserByCustomer($this->customerTransferMock),
+        );
+    }
+}

--- a/bundles/business-on-behalf-rest-api/tests/FondOfOryx/Zed/BusinessOnBehalfRestApi/Dependency/Facade/BusinessOnBehalfRestApiToCompanyUserFacadeBridgeTest.php
+++ b/bundles/business-on-behalf-rest-api/tests/FondOfOryx/Zed/BusinessOnBehalfRestApi/Dependency/Facade/BusinessOnBehalfRestApiToCompanyUserFacadeBridgeTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade;
+
+use Codeception\Test\Unit;
+use Generated\Shared\Transfer\CompanyUserTransfer;
+use PHPUnit\Framework\MockObject\MockObject;
+use Spryker\Zed\CompanyUser\Business\CompanyUserFacadeInterface;
+
+class BusinessOnBehalfRestApiToCompanyUserFacadeBridgeTest extends Unit
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|(\Spryker\Zed\CompanyUser\Business\CompanyUserFacadeInterface&\PHPUnit\Framework\MockObject\MockObject)
+     */
+    protected CompanyUserFacadeInterface|MockObject $facadeMock;
+
+    /**
+     * @var (\Generated\Shared\Transfer\CompanyUserTransfer&\PHPUnit\Framework\MockObject\MockObject)|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected CompanyUserTransfer|MockObject $companyUserTransferMock;
+
+    /**
+     * @var \FondOfOryx\Zed\BusinessOnBehalfRestApi\Dependency\Facade\BusinessOnBehalfRestApiToCompanyUserFacadeBridge
+     */
+    protected BusinessOnBehalfRestApiToCompanyUserFacadeBridge $bridge;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        parent::_before();
+
+        $this->facadeMock = $this->getMockBuilder(CompanyUserFacadeInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companyUserTransferMock = $this->getMockBuilder(CompanyUserTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->bridge = new BusinessOnBehalfRestApiToCompanyUserFacadeBridge(
+            $this->facadeMock,
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetCompanyUserById(): void
+    {
+        $idCompanyUser = 1;
+
+        $this->facadeMock->expects(static::atLeastOnce())
+            ->method('getCompanyUserById')
+            ->with($idCompanyUser)
+            ->willReturn($this->companyUserTransferMock);
+
+        static::assertEquals(
+            $this->companyUserTransferMock,
+            $this->bridge->getCompanyUserById($idCompanyUser),
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -433,6 +433,7 @@
       "FondOfOryx\\Shared\\AvailabilityAlertCrossEngage\\": "bundles/availability-alert-cross-engage/src/FondOfOryx/Shared/AvailabilityAlertCrossEngage",
       "FondOfOryx\\Shared\\AvailabilityAlertMigrator\\": "bundles/availability-alert-migrator/src/FondOfOryx/Shared/AvailabilityAlertMigrator",
       "FondOfOryx\\Shared\\BrandsRestApiExtension\\": "bundles/brands-rest-api-extension/src/FondOfOryx/Shared/BrandsRestApiExtension",
+      "FondOfOryx\\Shared\\BusinessOnBehalfRestApi\\": "bundles/business-on-behalf-rest-api/src/FondOfOryx/Shared/BusinessOnBehalfRestApi",
       "FondOfOryx\\Shared\\CartSearchRestApi\\": "bundles/cart-search-rest-api/src/FondOfOryx/Shared/CartSearchRestApi",
       "FondOfOryx\\Shared\\CatalogSkuFilter\\": "bundles/catalog-sku-filter/src/FondOfOryx/Shared/CatalogSkuFilter",
       "FondOfOryx\\Shared\\CustomerRegistrationRestApi\\": "bundles/customer-registration-rest-api/src/FondOfOryx/Shared/CustomerRegistrationRestApi",


### PR DESCRIPTION
- facade contract allows to set default company user by `RestBusinessOnBehalfRequestTransfer`
- default flag will be set in `spy_company_user`
- there is only one default company user per customer
- add unit tests
- add shared constants for error messages and codes
- ...