### PR TITLE
✨ Make `companies-rest-api-permission`-bundle releasable

### DIFF
--- a/bundles/companies-rest-api-permission/tests/FondOfOryx/Client/CompaniesRestApiPermission/CompaniesRestApiPermissionClientTest.php
+++ b/bundles/companies-rest-api-permission/tests/FondOfOryx/Client/CompaniesRestApiPermission/CompaniesRestApiPermissionClientTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace FondOfOryx\Client\CompaniesRestApiPermission;
+
+use Codeception\Test\Unit;
+use FondOfOryx\Client\CompaniesRestApiPermission\Zed\CompaniesRestApiPermissionStubInterface;
+use Generated\Shared\Transfer\CompaniesRestApiPermissionRequestTransfer;
+use Generated\Shared\Transfer\CompaniesRestApiPermissionResponseTransfer;
+
+class CompaniesRestApiPermissionClientTest extends Unit
+{
+    /**
+     * @var \FondOfOryx\Client\CompaniesRestApiPermission\CompaniesRestApiPermissionFactory|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $factoryMock;
+
+    /**
+     * @var \FondOfOryx\Client\CompaniesRestApiPermission\Zed\CompaniesRestApiPermissionStubInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $zedStubMock;
+
+    /**
+     * @var \Generated\Shared\Transfer\CompaniesRestApiPermissionResponseTransfer|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $companiesRestApiPermissionResponseTransferMock;
+
+    /**
+     * @var \Generated\Shared\Transfer\CompaniesRestApiPermissionRequestTransfer|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $companiesRestApiPermissionRequestTransferMock;
+
+    /**
+     * @var \FondOfOryx\Client\CompaniesRestApiPermission\CompaniesRestApiPermissionClient
+     */
+    protected $client;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        parent::_before();
+
+        $this->factoryMock = $this->getMockBuilder(CompaniesRestApiPermissionFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->zedStubMock = $this->getMockBuilder(CompaniesRestApiPermissionStubInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companiesRestApiPermissionResponseTransferMock = $this->getMockBuilder(CompaniesRestApiPermissionResponseTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companiesRestApiPermissionRequestTransferMock = $this->getMockBuilder(CompaniesRestApiPermissionRequestTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->client = new CompaniesRestApiPermissionClient();
+        $this->client->setFactory($this->factoryMock);
+    }
+
+    /**
+     * @return void
+     */
+    public function testHasPermissionToDeleteCompany(): void
+    {
+        $this->factoryMock->expects(static::atLeastOnce())
+            ->method('createCompaniesRestApiPermissionStub')
+            ->willReturn($this->zedStubMock);
+
+        $this->companiesRestApiPermissionResponseTransferMock->expects(static::atLeastOnce())
+            ->method('getHasPermissionToDelete')
+            ->willReturn(true);
+
+        $this->zedStubMock->expects(static::atLeastOnce())
+            ->method('hasPermissionToDeleteCompany')
+            ->with($this->companiesRestApiPermissionRequestTransferMock)
+            ->willReturn($this->companiesRestApiPermissionResponseTransferMock);
+
+        static::assertTrue(
+            $this->client->hasPermissionToDeleteCompany($this->companiesRestApiPermissionRequestTransferMock),
+        );
+    }
+}

--- a/bundles/companies-rest-api-permission/tests/FondOfOryx/Client/CompaniesRestApiPermission/CompaniesRestApiPermissionFactoryTest.php
+++ b/bundles/companies-rest-api-permission/tests/FondOfOryx/Client/CompaniesRestApiPermission/CompaniesRestApiPermissionFactoryTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace FondOfOryx\Client\CompaniesRestApiPermission;
+
+use Codeception\Test\Unit;
+use FondOfOryx\Client\CompaniesRestApiPermission\Dependency\Client\CompaniesRestApiPermissionToZedRequestInterface;
+use FondOfOryx\Client\CompaniesRestApiPermission\Zed\CompaniesRestApiPermissionStub;
+use Spryker\Client\Kernel\Container;
+
+class CompaniesRestApiPermissionFactoryTest extends Unit
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Client\Kernel\Container
+     */
+    protected $containerMock;
+
+    /**
+     * @var \FondOfOryx\Client\CompaniesRestApiPermission\Dependency\Client\CompaniesRestApiPermissionToZedRequestInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $zedRequestClientMock;
+
+    /**
+     * @var \FondOfOryx\Client\CompaniesRestApiPermission\CompaniesRestApiPermissionFactory
+     */
+    protected $factory;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        parent::_before();
+
+        $this->containerMock = $this->getMockBuilder(Container::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->zedRequestClientMock = $this->getMockBuilder(CompaniesRestApiPermissionToZedRequestInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->factory = new CompaniesRestApiPermissionFactory();
+        $this->factory->setContainer($this->containerMock);
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreateZedCompaniesRestApiPermissionStub(): void
+    {
+        $this->containerMock->expects(static::atLeastOnce())
+            ->method('has')
+            ->willReturn(true);
+
+        $this->containerMock->expects(static::atLeastOnce())
+            ->method('get')
+            ->with(CompaniesRestApiPermissionDependencyProvider::CLIENT_ZED_REQUEST)
+            ->willReturn($this->zedRequestClientMock);
+
+        static::assertInstanceOf(
+            CompaniesRestApiPermissionStub::class,
+            $this->factory->createCompaniesRestApiPermissionStub(),
+        );
+    }
+}

--- a/bundles/companies-rest-api-permission/tests/FondOfOryx/Client/CompaniesRestApiPermission/Dependency/Client/CompaniesRestApiPermissionToZedRequestClientBridgeTest.php
+++ b/bundles/companies-rest-api-permission/tests/FondOfOryx/Client/CompaniesRestApiPermission/Dependency/Client/CompaniesRestApiPermissionToZedRequestClientBridgeTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace FondOfOryx\Client\CompaniesRestApiPermission\Dependency\Client;
+
+use Codeception\Test\Unit;
+use Spryker\Client\ZedRequest\ZedRequestClientInterface;
+use Spryker\Shared\Kernel\Transfer\TransferInterface;
+
+class CompaniesRestApiPermissionToZedRequestClientBridgeTest extends Unit
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Client\ZedRequest\ZedRequestClientInterface
+     */
+    protected $zedRequestClientMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Shared\Kernel\Transfer\TransferInterface
+     */
+    protected $transferMock;
+
+    /**
+     * @var \FondOfOryx\Client\CompaniesRestApiPermission\Dependency\Client\CompaniesRestApiPermissionToZedRequestBridge
+     */
+    protected $zedRequestClientBridge;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        parent::_before();
+
+        $this->zedRequestClientMock = $this->getMockBuilder(ZedRequestClientInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->transferMock = $this->getMockBuilder(TransferInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->zedRequestClientBridge = new CompaniesRestApiPermissionToZedRequestBridge(
+            $this->zedRequestClientMock,
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testCall(): void
+    {
+        $url = 'url';
+
+        $this->zedRequestClientMock->expects(static::atLeastOnce())
+            ->method('call')
+            ->with($url, $this->transferMock, null)
+            ->willReturn($this->transferMock);
+
+        static::assertEquals(
+            $this->transferMock,
+            $this->zedRequestClientBridge->call($url, $this->transferMock),
+        );
+    }
+}

--- a/bundles/companies-rest-api-permission/tests/FondOfOryx/Client/CompaniesRestApiPermission/Zed/CompaniesRestApiPermissionStubTest.php
+++ b/bundles/companies-rest-api-permission/tests/FondOfOryx/Client/CompaniesRestApiPermission/Zed/CompaniesRestApiPermissionStubTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace FondOfOryx\Client\CompaniesRestApiPermission\Zed;
+
+use Codeception\Test\Unit;
+use FondOfOryx\Client\CompaniesRestApiPermission\Dependency\Client\CompaniesRestApiPermissionToZedRequestInterface;
+use Generated\Shared\Transfer\CompaniesRestApiPermissionRequestTransfer;
+use Generated\Shared\Transfer\CompaniesRestApiPermissionResponseTransfer;
+
+class CompaniesRestApiPermissionStubTest extends Unit
+{
+    /**
+     * @var \Generated\Shared\Transfer\CompaniesRestApiPermissionRequestTransfer|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $companiesRestApiPermissionRequestTransferMock;
+
+    /**
+     * @var \Generated\Shared\Transfer\CompaniesRestApiPermissionResponseTransfer|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $companiesRestApiPermissionResponseTransferMock;
+
+    /**
+     * @var \FondOfOryx\Client\CompaniesRestApiPermission\Dependency\Client\CompaniesRestApiPermissionToZedRequestInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $zedRequestClientMock;
+
+    /**
+     * @var \FondOfOryx\Client\CompaniesRestApiPermission\Zed\CompaniesRestApiPermissionStub
+     */
+    protected $stub;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        parent::_before();
+
+        $this->companiesRestApiPermissionRequestTransferMock = $this->getMockBuilder(CompaniesRestApiPermissionRequestTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companiesRestApiPermissionResponseTransferMock = $this->getMockBuilder(CompaniesRestApiPermissionResponseTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->zedRequestClientMock = $this->getMockBuilder(CompaniesRestApiPermissionToZedRequestInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->stub = new CompaniesRestApiPermissionStub($this->zedRequestClientMock);
+    }
+
+    /**
+     * @return void
+     */
+    public function testHasPermissionToDeleteCompany(): void
+    {
+        $this->zedRequestClientMock->expects(static::atLeastOnce())
+            ->method('call')
+            ->with(
+                '/companies-rest-api-permission/gateway/has-permission-to-delete-company',
+                $this->companiesRestApiPermissionRequestTransferMock,
+            )->willReturn($this->companiesRestApiPermissionResponseTransferMock);
+
+        static::assertEquals(
+            $this->companiesRestApiPermissionResponseTransferMock,
+            $this->stub->hasPermissionToDeleteCompany($this->companiesRestApiPermissionRequestTransferMock),
+        );
+    }
+}

--- a/bundles/companies-rest-api-permission/tests/FondOfOryx/Zed/CompaniesRestApiPermission/Communication/Controller/GatewayControllerTest.php
+++ b/bundles/companies-rest-api-permission/tests/FondOfOryx/Zed/CompaniesRestApiPermission/Communication/Controller/GatewayControllerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace FondOfOryx\Zed\CompaniesRestApiPermission\Communication\Controller;
+
+use Codeception\Test\Unit;
+use FondOfOryx\Zed\CompaniesRestApiPermission\Persistence\CompaniesRestApiPermissionRepository;
+use Generated\Shared\Transfer\CompaniesRestApiPermissionRequestTransfer;
+use Spryker\Zed\Kernel\Persistence\AbstractRepository;
+
+class GatewayControllerTest extends Unit
+{
+    /**
+     * @var \FondOfOryx\Zed\CompaniesRestApiPermission\Persistence\CompaniesRestApiPermissionRepositoryInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $repositoryMock;
+
+    /**
+     * @var \Generated\Shared\Transfer\CompaniesRestApiPermissionRequestTransfer|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $companiesRestApiPermissionRequestTransferMock;
+
+    /**
+     * @var \FondOfOryx\Zed\CompaniesRestApiPermission\Communication\Controller\GatewayController
+     */
+    protected $gatewayController;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        parent::_before();
+
+        $this->repositoryMock = $this->getMockBuilder(CompaniesRestApiPermissionRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companiesRestApiPermissionRequestTransferMock = $this->getMockBuilder(CompaniesRestApiPermissionRequestTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->gatewayController = new class ($this->repositoryMock) extends GatewayController {
+            /**
+             * @var \Spryker\Zed\Kernel\Persistence\AbstractRepository
+             */
+            protected $companiesRestApiRepository;
+
+            /**
+             * @param \Spryker\Zed\Kernel\Persistence\AbstractRepository $repository
+             */
+            public function __construct(AbstractRepository $repository)
+            {
+                $this->companiesRestApiRepository = $repository;
+            }
+
+            /**
+             * @return \Spryker\Zed\Kernel\Persistence\AbstractRepository
+             */
+            protected function getRepository()
+            {
+                return $this->companiesRestApiRepository;
+            }
+        };
+    }
+
+    /**
+     * @return void
+     */
+    public function testHasPermissionToDeleteCompanyAction(): void
+    {
+        $permissionKey = 'permission_key';
+        $custRef = 'cust_ref';
+        $uuid = 'uuid';
+
+        $this->repositoryMock->expects(static::atLeastOnce())
+            ->method('hasPermissionToDeleteCompany')
+            ->withConsecutive(
+                [$permissionKey],
+                [$custRef],
+                [$uuid],
+            )
+            ->willReturn(true);
+
+        $this->companiesRestApiPermissionRequestTransferMock->expects(static::atLeastOnce())
+            ->method('getPermissionKey')
+            ->willReturn($permissionKey);
+
+        $this->companiesRestApiPermissionRequestTransferMock->expects(static::atLeastOnce())
+            ->method('getCustomerReference')
+            ->willReturn($custRef);
+
+        $this->companiesRestApiPermissionRequestTransferMock->expects(static::atLeastOnce())
+            ->method('getCompanyUuid')
+            ->willReturn($uuid);
+
+        $this->gatewayController->hasPermissionToDeleteCompanyAction($this->companiesRestApiPermissionRequestTransferMock);
+    }
+}

--- a/codeception.yml
+++ b/codeception.yml
@@ -15,6 +15,7 @@ include:
   - bundles/cart-search-rest-api
   - bundles/cart-search-rest-api-extension
   - bundles/catalog-sku-filter
+  - bundles/companies-rest-api-permission
   - bundles/company-api
   - bundles/company-user-archive
   - bundles/company-brand-product-list-connector

--- a/dandelion.json
+++ b/dandelion.json
@@ -62,13 +62,13 @@
       "path": "bundles/catalog-sku-filter/",
       "version": "2.0.0"
     },
+    "companies-rest-api-permission": {
+      "path": "bundles/companies-rest-api-permission/",
+      "version": "1.0.0"
+    },
     "company-api": {
       "path": "bundles/company-api/",
       "version": "3.0.0"
-    },
-    "companies-rest-api-permission": {
-      "path": "bundles/companies-rest-api-permission/",
-      "version": "1.0.0-beta"
     },
     "company-brand-product-list-connector": {
       "path": "bundles/company-brand-product-list-connector/",


### PR DESCRIPTION
- add unit tests to `companies-rest-api-permission`-bundle
- include `companies-rest-api-permission`-bundle in main codeception.yaml
- include `companies-rest-api-permission`-bundle in dandelion.json to create first (beta-)release
- ...