### PR TITLE
🧩 get current locale from LocaleFacade

### DIFF
--- a/bundles/customer-registration/composer.json
+++ b/bundles/customer-registration/composer.json
@@ -12,7 +12,8 @@
     "php": ">=8.0",
     "spryker/customer": "^7.30.0",
     "fond-of-oryx/one-time-password": "^2.0.0",
-    "spryker/event-behavior": "^1.0.0"
+    "spryker/event-behavior": "^1.0.0",
+    "spryker/locale": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "require-dev": {
     "fond-of-codeception/spryker": "^1.0",

--- a/bundles/customer-registration/src/FondOfOryx/Zed/CustomerRegistration/Communication/CustomerRegistrationCommunicationFactory.php
+++ b/bundles/customer-registration/src/FondOfOryx/Zed/CustomerRegistration/Communication/CustomerRegistrationCommunicationFactory.php
@@ -4,6 +4,7 @@ namespace FondOfOryx\Zed\CustomerRegistration\Communication;
 
 use FondOfOryx\Zed\CustomerRegistration\CustomerRegistrationDependencyProvider;
 use FondOfOryx\Zed\CustomerRegistration\Dependency\Facade\CustomerRegistrationToCustomerFacadeInterface;
+use FondOfOryx\Zed\CustomerRegistration\Dependency\Facade\CustomerRegistrationToLocaleFacadeInterface;
 use FondOfOryx\Zed\CustomerRegistration\Dependency\Facade\CustomerRegistrationToMailFacadeInterface;
 use FondOfOryx\Zed\CustomerRegistration\Dependency\Facade\CustomerRegistrationToOneTimePasswordFacadeInterface;
 use Spryker\Zed\Kernel\Communication\AbstractCommunicationFactory;
@@ -32,5 +33,13 @@ class CustomerRegistrationCommunicationFactory extends AbstractCommunicationFact
     public function getOneTimePasswordFacade(): CustomerRegistrationToOneTimePasswordFacadeInterface
     {
         return $this->getProvidedDependency(CustomerRegistrationDependencyProvider::FACADE_ONE_TIME_PASSWORD);
+    }
+
+    /**
+     * @return \FondOfOryx\Zed\CustomerRegistration\Dependency\Facade\CustomerRegistrationToLocaleFacadeInterface
+     */
+    public function getLocaleFacade(): CustomerRegistrationToLocaleFacadeInterface
+    {
+        return $this->getProvidedDependency(CustomerRegistrationDependencyProvider::FACADE_LOCALE);
     }
 }

--- a/bundles/customer-registration/src/FondOfOryx/Zed/CustomerRegistration/Communication/Plugins/Mail/CustomerRegistrationConfirmationMailjetMailTypeBuilder.php
+++ b/bundles/customer-registration/src/FondOfOryx/Zed/CustomerRegistration/Communication/Plugins/Mail/CustomerRegistrationConfirmationMailjetMailTypeBuilder.php
@@ -9,6 +9,7 @@ use Spryker\Zed\MailExtension\Dependency\Plugin\MailTypeBuilderPluginInterface;
 
 /**
  * @method \FondOfOryx\Zed\CustomerRegistration\CustomerRegistrationConfig getConfig()
+ * @method \FondOfOryx\Zed\CustomerRegistration\Communication\CustomerRegistrationCommunicationFactory getFactory()
  */
 class CustomerRegistrationConfirmationMailjetMailTypeBuilder extends AbstractPlugin implements MailTypeBuilderPluginInterface
 {
@@ -54,7 +55,7 @@ class CustomerRegistrationConfirmationMailjetMailTypeBuilder extends AbstractPlu
     {
         $mailjetTemplateTransfer = (new MailjetTemplateTransfer())
             ->setSubject(static::GLOSSARY_KEY_MAIL_SUBJECT)
-            ->setTemplateId($this->getTemplateId($mailTransfer));
+            ->setTemplateId($this->getTemplateId());
 
         return $mailTransfer->setMailjetTemplate(
             $this->setVariables($mailTransfer, $mailjetTemplateTransfer),
@@ -81,16 +82,17 @@ class CustomerRegistrationConfirmationMailjetMailTypeBuilder extends AbstractPlu
     }
 
     /**
-     * @param \Generated\Shared\Transfer\MailTransfer $mailTransfer
-     *
      * @return int
      */
-    protected function getTemplateId(MailTransfer $mailTransfer): int
+    protected function getTemplateId(): int
     {
         $locale = static::DEFAULT_LOCALE;
-        $localeTransfer = $mailTransfer->getCustomer()->getLocale();
 
-        if ($localeTransfer !== null) {
+        $localeTransfer = $this->getFactory()
+            ->getLocaleFacade()
+            ->getCurrentLocale();
+
+        if ($localeTransfer->getLocaleName() !== null) {
             $locale = $localeTransfer->getLocaleName();
         }
 

--- a/bundles/customer-registration/src/FondOfOryx/Zed/CustomerRegistration/Communication/Plugins/Mail/CustomerRegistrationWelcomeMailjetMailTypeBuilder.php
+++ b/bundles/customer-registration/src/FondOfOryx/Zed/CustomerRegistration/Communication/Plugins/Mail/CustomerRegistrationWelcomeMailjetMailTypeBuilder.php
@@ -9,6 +9,7 @@ use Spryker\Zed\MailExtension\Dependency\Plugin\MailTypeBuilderPluginInterface;
 
 /**
  * @method \FondOfOryx\Zed\CustomerRegistration\CustomerRegistrationConfig getConfig()
+ * @method \FondOfOryx\Zed\CustomerRegistration\Communication\CustomerRegistrationCommunicationFactory getFactory()
  */
 class CustomerRegistrationWelcomeMailjetMailTypeBuilder extends AbstractPlugin implements MailTypeBuilderPluginInterface
 {
@@ -72,7 +73,7 @@ class CustomerRegistrationWelcomeMailjetMailTypeBuilder extends AbstractPlugin i
     {
         $mailjetTemplateTransfer = (new MailjetTemplateTransfer())
             ->setSubject(static::GLOSSARY_KEY_MAIL_SUBJECT)
-            ->setTemplateId($this->getTemplateId($mailTransfer));
+            ->setTemplateId($this->getTemplateId());
 
         return $mailTransfer->setMailjetTemplate(
             $this->setVariables($mailTransfer, $mailjetTemplateTransfer),
@@ -99,16 +100,17 @@ class CustomerRegistrationWelcomeMailjetMailTypeBuilder extends AbstractPlugin i
     }
 
     /**
-     * @param \Generated\Shared\Transfer\MailTransfer $mailTransfer
-     *
      * @return int
      */
-    protected function getTemplateId(MailTransfer $mailTransfer): int
+    protected function getTemplateId(): int
     {
         $locale = static::DEFAULT_LOCALE;
-        $localeTransfer = $mailTransfer->getCustomer()->getLocale();
 
-        if ($localeTransfer !== null) {
+        $localeTransfer = $this->getFactory()
+            ->getLocaleFacade()
+            ->getCurrentLocale();
+
+        if ($localeTransfer->getLocaleName() !== null) {
             $locale = $localeTransfer->getLocaleName();
         }
 

--- a/bundles/customer-registration/src/FondOfOryx/Zed/CustomerRegistration/CustomerRegistrationDependencyProvider.php
+++ b/bundles/customer-registration/src/FondOfOryx/Zed/CustomerRegistration/CustomerRegistrationDependencyProvider.php
@@ -3,6 +3,7 @@
 namespace FondOfOryx\Zed\CustomerRegistration;
 
 use FondOfOryx\Zed\CustomerRegistration\Dependency\Facade\CustomerRegistrationToCustomerFacadeBridge;
+use FondOfOryx\Zed\CustomerRegistration\Dependency\Facade\CustomerRegistrationToLocaleFacadeBridge;
 use FondOfOryx\Zed\CustomerRegistration\Dependency\Facade\CustomerRegistrationToMailFacadeBridge;
 use FondOfOryx\Zed\CustomerRegistration\Dependency\Facade\CustomerRegistrationToOneTimePasswordFacadeBridge;
 use FondOfOryx\Zed\CustomerRegistration\Dependency\QueryContainer\CustomerRegistrationToCustomerQueryContainerBridge;
@@ -30,6 +31,11 @@ class CustomerRegistrationDependencyProvider extends AbstractBundleDependencyPro
      * @var string
      */
     public const QUERY_CONTAINER_CUSTOMER = 'QUERY_CONTAINER_CUSTOMER';
+
+    /**
+     * @var string
+     */
+    public const FACADE_LOCALE = 'FACADE_LOCALE';
 
     /**
      * @param \Spryker\Zed\Kernel\Container $container
@@ -130,6 +136,22 @@ class CustomerRegistrationDependencyProvider extends AbstractBundleDependencyPro
         $container[static::FACADE_MAIL] = static function (Container $container) {
             return new CustomerRegistrationToMailFacadeBridge(
                 $container->getLocator()->mail()->facade(),
+            );
+        };
+
+        return $container;
+    }
+
+    /**
+     * @param \Spryker\Zed\Kernel\Container $container
+     *
+     * @return \Spryker\Zed\Kernel\Container
+     */
+    protected function addLocaleFacade(Container $container): Container
+    {
+        $container[static::FACADE_LOCALE] = static function (Container $container) {
+            return new CustomerRegistrationToLocaleFacadeBridge(
+                $container->getLocator()->locale()->facade(),
             );
         };
 

--- a/bundles/customer-registration/src/FondOfOryx/Zed/CustomerRegistration/Dependency/Facade/CustomerRegistrationToLocaleFacadeBridge.php
+++ b/bundles/customer-registration/src/FondOfOryx/Zed/CustomerRegistration/Dependency/Facade/CustomerRegistrationToLocaleFacadeBridge.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace FondOfOryx\Zed\CustomerRegistration\Dependency\Facade;
+
+use Generated\Shared\Transfer\LocaleTransfer;
+use Spryker\Zed\Locale\Business\LocaleFacadeInterface;
+
+class CustomerRegistrationToLocaleFacadeBridge implements CustomerRegistrationToLocaleFacadeInterface
+{
+    /**
+     * @var \Spryker\Zed\Locale\Business\LocaleFacadeInterface
+     */
+    protected $localeFacade;
+
+    /**
+     * @param \Spryker\Zed\Locale\Business\LocaleFacadeInterface $localeFacade
+     */
+    public function __construct(LocaleFacadeInterface $localeFacade)
+    {
+        $this->localeFacade = $localeFacade;
+    }
+
+    /**
+     * @return \Generated\Shared\Transfer\LocaleTransfer
+     */
+    public function getCurrentLocale(): LocaleTransfer
+    {
+        return $this->localeFacade->getCurrentLocale();
+    }
+}

--- a/bundles/customer-registration/src/FondOfOryx/Zed/CustomerRegistration/Dependency/Facade/CustomerRegistrationToLocaleFacadeInterface.php
+++ b/bundles/customer-registration/src/FondOfOryx/Zed/CustomerRegistration/Dependency/Facade/CustomerRegistrationToLocaleFacadeInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace FondOfOryx\Zed\CustomerRegistration\Dependency\Facade;
+
+use Generated\Shared\Transfer\LocaleTransfer;
+
+interface CustomerRegistrationToLocaleFacadeInterface
+{
+    /**
+     * @return \Generated\Shared\Transfer\LocaleTransfer
+     */
+    public function getCurrentLocale(): LocaleTransfer;
+}

--- a/bundles/customer-registration/tests/FondOfOryx/Zed/CustomerRegistration/Communication/Plugins/Mail/CustomerRegistrationConfirmationMailjetMailTypeBuilderTest.php
+++ b/bundles/customer-registration/tests/FondOfOryx/Zed/CustomerRegistration/Communication/Plugins/Mail/CustomerRegistrationConfirmationMailjetMailTypeBuilderTest.php
@@ -3,13 +3,25 @@
 namespace FondOfOryx\Zed\CustomerRegistration\Communication\Plugins\Mail;
 
 use Codeception\Test\Unit;
+use FondOfOryx\Zed\CustomerRegistration\Communication\CustomerRegistrationCommunicationFactory;
 use FondOfOryx\Zed\CustomerRegistration\CustomerRegistrationConfig;
+use FondOfOryx\Zed\CustomerRegistration\Dependency\Facade\CustomerRegistrationToLocaleFacadeBridge;
 use Generated\Shared\Transfer\CustomerTransfer;
 use Generated\Shared\Transfer\LocaleTransfer;
 use Generated\Shared\Transfer\MailTransfer;
 
 class CustomerRegistrationConfirmationMailjetMailTypeBuilderTest extends Unit
 {
+    /**
+     * @var \FondOfOryx\Zed\CustomerRegistration\Communication\CustomerRegistrationCommunicationFactory|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $communicationFactoryMock;
+
+    /**
+     * @var \FondOfOryx\Zed\CustomerRegistration\Dependency\Facade\CustomerRegistrationToLocaleFacadeInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $localeFacadeMock;
+
     /**
      * @var \Generated\Shared\Transfer\MailTransfer|\PHPUnit\Framework\MockObject\MockObject
      */
@@ -58,8 +70,17 @@ class CustomerRegistrationConfirmationMailjetMailTypeBuilderTest extends Unit
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->communicationFactoryMock = $this->getMockBuilder(CustomerRegistrationCommunicationFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->localeFacadeMock = $this->getMockBuilder(CustomerRegistrationToLocaleFacadeBridge::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $this->plugin = new CustomerRegistrationConfirmationMailjetMailTypeBuilder();
         $this->plugin->setConfig($this->configMock);
+        $this->plugin->setFactory($this->communicationFactoryMock);
     }
 
     /**
@@ -83,16 +104,20 @@ class CustomerRegistrationConfirmationMailjetMailTypeBuilderTest extends Unit
             ->willReturn($this->customerTransferMock);
 
         $this->customerTransferMock->expects(static::atLeastOnce())
-            ->method('getLocale')
-            ->willReturn($this->localeTransferMock);
-
-        $this->customerTransferMock->expects(static::atLeastOnce())
             ->method('getConfirmationLink')
             ->willReturn('CONFIRMATION_LINK');
 
         $this->customerTransferMock->expects(static::atLeastOnce())
             ->method('getEmail')
             ->willReturn('john.doe@fondof.de');
+
+        $this->communicationFactoryMock->expects(static::atLeastOnce())
+            ->method('getLocaleFacade')
+            ->willReturn($this->localeFacadeMock);
+
+        $this->localeFacadeMock->expects(static::atLeastOnce())
+            ->method('getCurrentLocale')
+            ->willReturn($this->localeTransferMock);
 
         $this->localeTransferMock->expects(static::atLeastOnce())
             ->method('getLocaleName')

--- a/bundles/customer-registration/tests/FondOfOryx/Zed/CustomerRegistration/Communication/Plugins/Mail/CustomerRegistrationWelcomeMailjetMailTypeBuilderTest.php
+++ b/bundles/customer-registration/tests/FondOfOryx/Zed/CustomerRegistration/Communication/Plugins/Mail/CustomerRegistrationWelcomeMailjetMailTypeBuilderTest.php
@@ -3,13 +3,25 @@
 namespace FondOfOryx\Zed\CustomerRegistration\Communication\Plugins\Mail;
 
 use Codeception\Test\Unit;
+use FondOfOryx\Zed\CustomerRegistration\Communication\CustomerRegistrationCommunicationFactory;
 use FondOfOryx\Zed\CustomerRegistration\CustomerRegistrationConfig;
+use FondOfOryx\Zed\CustomerRegistration\Dependency\Facade\CustomerRegistrationToLocaleFacadeBridge;
 use Generated\Shared\Transfer\CustomerTransfer;
 use Generated\Shared\Transfer\LocaleTransfer;
 use Generated\Shared\Transfer\MailTransfer;
 
 class CustomerRegistrationWelcomeMailjetMailTypeBuilderTest extends Unit
 {
+    /**
+     * @var \FondOfOryx\Zed\CustomerRegistration\Communication\CustomerRegistrationCommunicationFactory|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $communicationFactoryMock;
+
+    /**
+     * @var \FondOfOryx\Zed\CustomerRegistration\Dependency\Facade\CustomerRegistrationToLocaleFacadeInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $localeFacadeMock;
+
     /**
      * @var \Generated\Shared\Transfer\MailTransfer|\PHPUnit\Framework\MockObject\MockObject
      */
@@ -58,8 +70,17 @@ class CustomerRegistrationWelcomeMailjetMailTypeBuilderTest extends Unit
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->communicationFactoryMock = $this->getMockBuilder(CustomerRegistrationCommunicationFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->localeFacadeMock = $this->getMockBuilder(CustomerRegistrationToLocaleFacadeBridge::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $this->plugin = new CustomerRegistrationWelcomeMailjetMailTypeBuilder();
         $this->plugin->setConfig($this->configMock);
+        $this->plugin->setFactory($this->communicationFactoryMock);
     }
 
     /**
@@ -72,10 +93,6 @@ class CustomerRegistrationWelcomeMailjetMailTypeBuilderTest extends Unit
             ->willReturn($this->customerTransferMock);
 
         $this->customerTransferMock->expects(static::atLeastOnce())
-            ->method('getLocale')
-            ->willReturn($this->localeTransferMock);
-
-        $this->customerTransferMock->expects(static::atLeastOnce())
             ->method('getFirstName')
             ->willReturn('John');
 
@@ -86,6 +103,14 @@ class CustomerRegistrationWelcomeMailjetMailTypeBuilderTest extends Unit
         $this->mailTransferMock->expects(static::atLeastOnce())
             ->method('getOneTimePasswordLoginLink')
             ->willReturn('ONE_TIME_PASSWORD_LINK');
+
+        $this->communicationFactoryMock->expects(static::atLeastOnce())
+            ->method('getLocaleFacade')
+            ->willReturn($this->localeFacadeMock);
+
+        $this->localeFacadeMock->expects(static::atLeastOnce())
+            ->method('getCurrentLocale')
+            ->willReturn($this->localeTransferMock);
 
         $this->localeTransferMock->expects(static::atLeastOnce())
             ->method('getLocaleName')

--- a/dandelion.json
+++ b/dandelion.json
@@ -321,7 +321,7 @@
     },
     "customer-registration": {
       "path": "bundles/customer-registration/",
-      "version": "2.1.1"
+      "version": "2.1.2"
     },
     "customer-registration-rest-api": {
       "path": "bundles/customer-registration-rest-api/",


### PR DESCRIPTION
**Description**

at this point it is not possible to get the locale via mail- or customer-transfer. Therefore, a bridge to the LocaleFacade was created that takes over this task.

