### PR TITLE
♻️ refactor : Allow to test bundle availability-alert-cross-engage standalone

### DIFF
--- a/bundles/availability-alert-cross-engage/Makefile
+++ b/bundles/availability-alert-cross-engage/Makefile
@@ -20,3 +20,11 @@ codeception:
 
 .PHONY: ci
 ci: phpcs codeception phpstan
+
+.PHONY: clean
+clean:
+	rm -Rf composer.lock
+	rm -Rf ./vendor
+	find ./tests/_output/ -not -name .gitignore -delete
+	rm -Rf src/Generated/*
+	rm -Rf src/Orm/*

--- a/bundles/availability-alert-cross-engage/composer.json
+++ b/bundles/availability-alert-cross-engage/composer.json
@@ -10,13 +10,12 @@
   ],
   "require": {
     "php": ">=8.0",
-    "fond-of-oryx/availability-alert": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "fond-of-oryx/availability-alert-migrator": "^1.0.0 || ^2.0.0",
     "fond-of-oryx/cross-engage": "^1.0.0 || ^2.0.0",
     "fond-of-oryx/jellyfish-availability-alert": "^1.1.0 || ^2.0.0"
   },
   "require-dev": {
-    "fond-of-codeception/spryker": "^1.0",
+    "fond-of-codeception/spryker": "*",
     "spryker/code-sniffer": "*",
     "spryker-sdk/phpstan-spryker": "*"
   },


### PR DESCRIPTION
- cleanup  availability-alert-cross-engage with the help of the bash script