### PR TITLE
chore: fix missing config

### DIFF
--- a/bundles/one-time-password-email-connector/src/FondOfOryx/Zed/OneTimePasswordEmailConnector/Communication/Plugin/Mail/OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPlugin.php
+++ b/bundles/one-time-password-email-connector/src/FondOfOryx/Zed/OneTimePasswordEmailConnector/Communication/Plugin/Mail/OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPlugin.php
@@ -36,19 +36,6 @@ class OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPlugin extends Abstra
     protected const GLOSSARY_KEY_MAIL_SUBJECT = 'mail.customer.one-time-password.login-link.subject';
 
     /**
-     * @var \Spryker\Zed\Mail\MailConfig
-     */
-    protected $config;
-
-    /**
-     * @param \Spryker\Zed\Mail\MailConfig $config
-     */
-    public function __construct(MailConfig $config)
-    {
-        $this->config = $config;
-    }
-
-    /**
      * @return string
      */
     public function getName(): string
@@ -85,11 +72,6 @@ class OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPlugin extends Abstra
                         ),
                     )
                     ->setEmail($mailTransfer->getCustomerOrFail()->getEmail()),
-            )
-            ->setSender(
-                (new MailSenderTransfer())
-                    ->setEmail($this->config->getSenderEmail())
-                    ->setName($this->config->getSenderName()),
             );
     }
 }

--- a/bundles/one-time-password-email-connector/src/FondOfOryx/Zed/OneTimePasswordEmailConnector/Communication/Plugin/Mail/OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPlugin.php
+++ b/bundles/one-time-password-email-connector/src/FondOfOryx/Zed/OneTimePasswordEmailConnector/Communication/Plugin/Mail/OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPlugin.php
@@ -3,11 +3,9 @@
 namespace FondOfOryx\Zed\OneTimePasswordEmailConnector\Communication\Plugin\Mail;
 
 use Generated\Shared\Transfer\MailRecipientTransfer;
-use Generated\Shared\Transfer\MailSenderTransfer;
 use Generated\Shared\Transfer\MailTemplateTransfer;
 use Generated\Shared\Transfer\MailTransfer;
 use Spryker\Zed\Kernel\Communication\AbstractPlugin;
-use Spryker\Zed\Mail\MailConfig;
 use Spryker\Zed\MailExtension\Dependency\Plugin\MailTypeBuilderPluginInterface;
 
 /**

--- a/bundles/one-time-password-email-connector/src/FondOfOryx/Zed/OneTimePasswordEmailConnector/Communication/Plugin/Mail/OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPlugin.php
+++ b/bundles/one-time-password-email-connector/src/FondOfOryx/Zed/OneTimePasswordEmailConnector/Communication/Plugin/Mail/OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPlugin.php
@@ -3,9 +3,11 @@
 namespace FondOfOryx\Zed\OneTimePasswordEmailConnector\Communication\Plugin\Mail;
 
 use Generated\Shared\Transfer\MailRecipientTransfer;
+use Generated\Shared\Transfer\MailSenderTransfer;
 use Generated\Shared\Transfer\MailTemplateTransfer;
 use Generated\Shared\Transfer\MailTransfer;
 use Spryker\Zed\Kernel\Communication\AbstractPlugin;
+use Spryker\Zed\Mail\MailConfig;
 use Spryker\Zed\MailExtension\Dependency\Plugin\MailTypeBuilderPluginInterface;
 
 /**
@@ -32,6 +34,19 @@ class OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPlugin extends Abstra
      * @var string
      */
     protected const GLOSSARY_KEY_MAIL_SUBJECT = 'mail.customer.one-time-password.login-link.subject';
+
+    /**
+     * @var \Spryker\Zed\Mail\MailConfig
+     */
+    protected $config;
+
+    /**
+     * @param \Spryker\Zed\Mail\MailConfig $config
+     */
+    public function __construct(MailConfig $config)
+    {
+        $this->config = $config;
+    }
 
     /**
      * @return string
@@ -70,6 +85,11 @@ class OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPlugin extends Abstra
                         ),
                     )
                     ->setEmail($mailTransfer->getCustomerOrFail()->getEmail()),
+            )
+            ->setSender(
+                (new MailSenderTransfer())
+                    ->setEmail($this->config->getSenderEmail())
+                    ->setName($this->config->getSenderName()),
             );
     }
 }

--- a/bundles/one-time-password-email-connector/tests/FondOfOryx/Zed/OneTimePasswordEmailConnector/Communication/Plugin/Mail/OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPluginTest.php
+++ b/bundles/one-time-password-email-connector/tests/FondOfOryx/Zed/OneTimePasswordEmailConnector/Communication/Plugin/Mail/OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPluginTest.php
@@ -28,7 +28,6 @@ class OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPluginTest extends Un
      */
     protected function _before(): void
     {
-
         $this->mailTransferMock = $this->getMockBuilder(MailTransfer::class)
             ->disableOriginalConstructor()
             ->getMock();

--- a/bundles/one-time-password-email-connector/tests/FondOfOryx/Zed/OneTimePasswordEmailConnector/Communication/Plugin/Mail/OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPluginTest.php
+++ b/bundles/one-time-password-email-connector/tests/FondOfOryx/Zed/OneTimePasswordEmailConnector/Communication/Plugin/Mail/OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPluginTest.php
@@ -5,15 +5,9 @@ namespace FondOfOryx\Zed\OneTimePasswordEmailConnector\Communication\Plugin\Mail
 use Codeception\Test\Unit;
 use Generated\Shared\Transfer\CustomerTransfer;
 use Generated\Shared\Transfer\MailTransfer;
-use Spryker\Zed\Mail\MailConfig;
 
 class OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPluginTest extends Unit
 {
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\Mail\MailConfig
-     */
-    protected $mailConfigMock;
-
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject|\Generated\Shared\Transfer\MailTransfer
      */
@@ -34,9 +28,6 @@ class OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPluginTest extends Un
      */
     protected function _before(): void
     {
-        $this->mailConfigMock = $this->getMockBuilder(MailConfig::class)
-            ->disableOriginalConstructor()
-            ->getMock();
 
         $this->mailTransferMock = $this->getMockBuilder(MailTransfer::class)
             ->disableOriginalConstructor()
@@ -46,7 +37,7 @@ class OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPluginTest extends Un
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->plugin = new OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPlugin($this->mailConfigMock);
+        $this->plugin = new OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPlugin();
     }
 
     /**
@@ -93,18 +84,6 @@ class OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPluginTest extends Un
         $this->mailTransferMock->expects(static::atLeastOnce())
             ->method('addRecipient')
             ->willReturnSelf();
-
-        $this->mailTransferMock->expects(static::atLeastOnce())
-            ->method('setSender')
-            ->willReturnSelf();
-
-        $this->mailConfigMock->expects(static::atLeastOnce())
-            ->method('getSenderEmail')
-            ->willReturn('sender.email@mailinator.com');
-
-        $this->mailConfigMock->expects(static::atLeastOnce())
-            ->method('getSenderName')
-            ->willReturn('Sender Name');
 
         $mailTransfer = $this->plugin->build($this->mailTransferMock);
 

--- a/bundles/one-time-password-email-connector/tests/FondOfOryx/Zed/OneTimePasswordEmailConnector/Communication/Plugin/Mail/OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPluginTest.php
+++ b/bundles/one-time-password-email-connector/tests/FondOfOryx/Zed/OneTimePasswordEmailConnector/Communication/Plugin/Mail/OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPluginTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace FondOfOryx\Zed\OneTimePasswordEmailConnector\Communication\Plugin\Mail;
+
+use Codeception\Test\Unit;
+use Generated\Shared\Transfer\CustomerTransfer;
+use Generated\Shared\Transfer\MailTransfer;
+use Spryker\Zed\Mail\MailConfig;
+
+class OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPluginTest extends Unit
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\Mail\MailConfig
+     */
+    protected $mailConfigMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Generated\Shared\Transfer\MailTransfer
+     */
+    protected $mailTransferMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Generated\Shared\Transfer\CustomerTransfer
+     */
+    protected $customerTransferMock;
+
+    /**
+     * @var \FondOfOryx\Zed\OneTimePasswordEmailConnector\Communication\Plugin\Mail\OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPlugin
+     */
+    protected $plugin;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        $this->mailConfigMock = $this->getMockBuilder(MailConfig::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->mailTransferMock = $this->getMockBuilder(MailTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->customerTransferMock = $this->getMockBuilder(CustomerTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->plugin = new OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPlugin($this->mailConfigMock);
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetName(): void
+    {
+        static::assertEquals(
+            OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPlugin::MAIL_TYPE,
+            $this->plugin->getName(),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuild(): void
+    {
+        $this->mailTransferMock->expects(static::atLeastOnce())
+            ->method('setSubject')
+            ->with('mail.customer.one-time-password.login-link.subject')
+            ->willReturnSelf();
+
+        $this->mailTransferMock->expects(static::atLeastOnce())
+            ->method('getCustomerOrFail')
+            ->willReturn($this->customerTransferMock);
+
+        $this->customerTransferMock->expects(static::atLeastOnce())
+            ->method('getFirstName')
+            ->willReturn('John');
+
+        $this->customerTransferMock->expects(static::atLeastOnce())
+            ->method('getLastName')
+            ->willReturn('Doe');
+
+        $this->customerTransferMock->expects(static::atLeastOnce())
+            ->method('getEmail')
+            ->willReturn('john.doe@mailinator.com');
+
+        $this->mailTransferMock->expects(static::atLeastOnce())
+            ->method('addTemplate')
+            ->willReturnSelf();
+
+        $this->mailTransferMock->expects(static::atLeastOnce())
+            ->method('addRecipient')
+            ->willReturnSelf();
+
+        $this->mailTransferMock->expects(static::atLeastOnce())
+            ->method('setSender')
+            ->willReturnSelf();
+
+        $this->mailConfigMock->expects(static::atLeastOnce())
+            ->method('getSenderEmail')
+            ->willReturn('sender.email@mailinator.com');
+
+        $this->mailConfigMock->expects(static::atLeastOnce())
+            ->method('getSenderName')
+            ->willReturn('Sender Name');
+
+        $mailTransfer = $this->plugin->build($this->mailTransferMock);
+
+        static::assertEquals($mailTransfer, $this->mailTransferMock);
+    }
+}

--- a/dandelion.json
+++ b/dandelion.json
@@ -657,7 +657,7 @@
     },
     "one-time-password-email-connector": {
       "path": "bundles/one-time-password-email-connector/",
-      "version": "2.2.1"
+      "version": "2.2.2"
     },
     "one-time-password-extension": {
       "path": "bundles/one-time-password-extension/",


### PR DESCRIPTION
**Changelog**

- get sender name and email form MailConfig inside OneTimePasswordEmailConnectorLoginLinkMailTypeBuilderPlugin