### PR TITLE
bugfix: typo in transfer

### DIFF
--- a/bundles/product-country-restriction-checkout-connector/src/FondOfOryx/Shared/ProductCountryRestrictionCheckoutConnector/Transfer/product_country_restriction_checkout_connector.transfer.xml
+++ b/bundles/product-country-restriction-checkout-connector/src/FondOfOryx/Shared/ProductCountryRestrictionCheckoutConnector/Transfer/product_country_restriction_checkout_connector.transfer.xml
@@ -22,7 +22,7 @@
     </transfer>
 
     <transfer name="BlacklistedCountry">
-        <property name="iso2code" type="string" />
+        <property name="iso2Code" type="string" />
     </transfer>
 
     <transfer name="Item">

--- a/dandelion.json
+++ b/dandelion.json
@@ -757,7 +757,7 @@
     },
     "product-country-restriction-checkout-connector": {
       "path": "bundles/product-country-restriction-checkout-connector/",
-      "version": "2.0.0"
+      "version": "2.0.1"
     },
     "product-default-category-assigner": {
       "path": "bundles/product-default-category-assigner/",


### PR DESCRIPTION
**Changelog/Description**

The typo in the transfer object itself has no impact on the code. However, an error is thrown when generating the transfer objects if there are different spellings.