### PR TITLE
fix: change shipment table rate calculation

### DIFF
--- a/bundles/shipment-table-rate/src/FondOfOryx/Zed/ShipmentTableRate/Communication/Plugin/ShipmentTableRateExtension/PriceToPayFilterPlugin.php
+++ b/bundles/shipment-table-rate/src/FondOfOryx/Zed/ShipmentTableRate/Communication/Plugin/ShipmentTableRateExtension/PriceToPayFilterPlugin.php
@@ -23,6 +23,6 @@ class PriceToPayFilterPlugin extends AbstractPlugin implements PriceToPayFilterP
      */
     public function filter(TotalsTransfer $totalsTransfer): ?int
     {
-        return $totalsTransfer->getPriceToPay();
+        return $totalsTransfer->getSubtotal() - $totalsTransfer->getDiscountTotal();
     }
 }

--- a/bundles/shipment-table-rate/tests/FondOfOryx/Zed/ShipmentTableRate/Communication/Plugin/ShipmentTableRateExtension/PriceToPayFilterPluginTest.php
+++ b/bundles/shipment-table-rate/tests/FondOfOryx/Zed/ShipmentTableRate/Communication/Plugin/ShipmentTableRateExtension/PriceToPayFilterPluginTest.php
@@ -34,16 +34,43 @@ class PriceToPayFilterPluginTest extends Unit
     /**
      * @return void
      */
-    public function testFilter(): void
+    public function testFilterWithDiscount(): void
     {
-        $priceToPay = 1295;
+        $subTotal = 1990;
+        $discount = 800;
 
         $this->totalsTransferMock->expects(static::atLeastOnce())
             ->method('getPriceToPay')
-            ->willReturn($priceToPay);
+            ->willReturn($subTotal);
+
+        $this->totalsTransferMock->expects(static::atLeastOnce())
+            ->method('getPriceToPay')
+            ->willReturn($discount);
 
         static::assertEquals(
-            $priceToPay,
+            $subTotal-$discount,
+            $this->priceToPayFilterPlugin->filter($this->totalsTransferMock),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testFilterWithoutDiscount(): void
+    {
+        $subTotal = 1990;
+        $discount = 0;
+
+        $this->totalsTransferMock->expects(static::atLeastOnce())
+            ->method('getPriceToPay')
+            ->willReturn($subTotal);
+
+        $this->totalsTransferMock->expects(static::atLeastOnce())
+            ->method('getPriceToPay')
+            ->willReturn($discount);
+
+        static::assertEquals(
+            $subTotal-$discount,
             $this->priceToPayFilterPlugin->filter($this->totalsTransferMock),
         );
     }

--- a/bundles/shipment-table-rate/tests/FondOfOryx/Zed/ShipmentTableRate/Communication/Plugin/ShipmentTableRateExtension/PriceToPayFilterPluginTest.php
+++ b/bundles/shipment-table-rate/tests/FondOfOryx/Zed/ShipmentTableRate/Communication/Plugin/ShipmentTableRateExtension/PriceToPayFilterPluginTest.php
@@ -48,7 +48,7 @@ class PriceToPayFilterPluginTest extends Unit
             ->willReturn($discount);
 
         static::assertEquals(
-            $subTotal-$discount,
+            $subTotal - $discount,
             $this->priceToPayFilterPlugin->filter($this->totalsTransferMock),
         );
     }
@@ -70,7 +70,7 @@ class PriceToPayFilterPluginTest extends Unit
             ->willReturn($discount);
 
         static::assertEquals(
-            $subTotal-$discount,
+            $subTotal - $discount,
             $this->priceToPayFilterPlugin->filter($this->totalsTransferMock),
         );
     }

--- a/bundles/shipment-table-rate/tests/FondOfOryx/Zed/ShipmentTableRate/Communication/Plugin/ShipmentTableRateExtension/PriceToPayFilterPluginTest.php
+++ b/bundles/shipment-table-rate/tests/FondOfOryx/Zed/ShipmentTableRate/Communication/Plugin/ShipmentTableRateExtension/PriceToPayFilterPluginTest.php
@@ -40,11 +40,11 @@ class PriceToPayFilterPluginTest extends Unit
         $discount = 800;
 
         $this->totalsTransferMock->expects(static::atLeastOnce())
-            ->method('getPriceToPay')
+            ->method('getSubtotal')
             ->willReturn($subTotal);
 
         $this->totalsTransferMock->expects(static::atLeastOnce())
-            ->method('getPriceToPay')
+            ->method('getDiscountTotal')
             ->willReturn($discount);
 
         static::assertEquals(
@@ -62,11 +62,11 @@ class PriceToPayFilterPluginTest extends Unit
         $discount = 0;
 
         $this->totalsTransferMock->expects(static::atLeastOnce())
-            ->method('getPriceToPay')
+            ->method('getSubtotal')
             ->willReturn($subTotal);
 
         $this->totalsTransferMock->expects(static::atLeastOnce())
-            ->method('getPriceToPay')
+            ->method('getDiscountTotal')
             ->willReturn($discount);
 
         static::assertEquals(

--- a/dandelion.json
+++ b/dandelion.json
@@ -873,7 +873,7 @@
     },
     "shipment-table-rate": {
       "path": "bundles/shipment-table-rate/",
-      "version": "2.0.1"
+      "version": "3.0.0"
     },
     "shipment-table-rate-data-import": {
       "path": "bundles/shipment-table-rate-data-import/",


### PR DESCRIPTION
Price to pay includes shipment expenses for that reason we will use subtotal subtracted by discounts, because grandTotal as well as price to pay includes discounts