### PR TITLE
🐛 fix missing required `CompanyUserTransfer` parameters in `CompanyUserPreDeletePlugins`

### DIFF
--- a/bundles/company-user-api/src/FondOfOryx/Zed/CompanyUserApi/Business/Model/CompanyUserApi.php
+++ b/bundles/company-user-api/src/FondOfOryx/Zed/CompanyUserApi/Business/Model/CompanyUserApi.php
@@ -119,7 +119,7 @@ class CompanyUserApi implements CompanyUserApiInterface
      */
     public function remove(int $idCompanyUser): ApiItemTransfer
     {
-        $companyUserTransfer =  $this->companyUserFacade->getCompanyUserById($idCompanyUser);
+        $companyUserTransfer = $this->companyUserFacade->getCompanyUserById($idCompanyUser);
 
         $this->companyUserFacade->deleteCompanyUser($companyUserTransfer);
 

--- a/bundles/company-user-api/src/FondOfOryx/Zed/CompanyUserApi/Business/Model/CompanyUserApi.php
+++ b/bundles/company-user-api/src/FondOfOryx/Zed/CompanyUserApi/Business/Model/CompanyUserApi.php
@@ -119,7 +119,7 @@ class CompanyUserApi implements CompanyUserApiInterface
      */
     public function remove(int $idCompanyUser): ApiItemTransfer
     {
-        $companyUserTransfer = (new CompanyUserTransfer())->setIdCompanyUser($idCompanyUser);
+        $companyUserTransfer =  $this->companyUserFacade->getCompanyUserById($idCompanyUser);
 
         $this->companyUserFacade->deleteCompanyUser($companyUserTransfer);
 

--- a/bundles/company-user-api/tests/FondOfOryx/Zed/CompanyUserApi/Business/Model/CompanyUserApiTest.php
+++ b/bundles/company-user-api/tests/FondOfOryx/Zed/CompanyUserApi/Business/Model/CompanyUserApiTest.php
@@ -356,13 +356,8 @@ class CompanyUserApiTest extends Unit
 
         $this->companyUserFacadeMock->expects(static::atLeastOnce())
             ->method('deleteCompanyUser')
-            ->with(
-                static::callback(
-                    static function (CompanyUserTransfer $companyUserTransfer) use ($idCompanyUser) {
-                        return $idCompanyUser === $companyUserTransfer->getIdCompanyUser();
-                    },
-                ),
-            )->willReturn($this->companyUserResponseTransferMock);
+            ->with($this->companyUserTransferMock)
+            ->willReturn($this->companyUserResponseTransferMock);
 
         $this->apiFacadeMock->expects(static::atLeastOnce())
             ->method('createApiItem')

--- a/bundles/company-user-api/tests/FondOfOryx/Zed/CompanyUserApi/Business/Model/CompanyUserApiTest.php
+++ b/bundles/company-user-api/tests/FondOfOryx/Zed/CompanyUserApi/Business/Model/CompanyUserApiTest.php
@@ -350,6 +350,11 @@ class CompanyUserApiTest extends Unit
         $idCompanyUser = 1;
 
         $this->companyUserFacadeMock->expects(static::atLeastOnce())
+            ->method('getCompanyUserById')
+            ->with($idCompanyUser)
+            ->willReturn($this->companyUserTransferMock);
+
+        $this->companyUserFacadeMock->expects(static::atLeastOnce())
             ->method('deleteCompanyUser')
             ->with(
                 static::callback(

--- a/dandelion.json
+++ b/dandelion.json
@@ -249,7 +249,7 @@
     },
     "company-user-api": {
       "path": "bundles/company-user-api/",
-      "version": "3.1.0"
+      "version": "3.1.1"
     },
     "company-user-archive": {
       "path": "bundles/company-user-archive/",


### PR DESCRIPTION
- Retrieve `CompanyUserTransfer` by id in order to get all the `CompanyUser` Informations which are required in case of a few `CompanyUserPreDeletePlugins` 