### PR TITLE
feat: persist initial budget also

### DIFF
--- a/bundles/order-budget-search-rest-api/src/FondOfOryx/Shared/OrderBudgetSearchRestApi/Transfer/order_budget_search_rest_api.transfer.xml
+++ b/bundles/order-budget-search-rest-api/src/FondOfOryx/Shared/OrderBudgetSearchRestApi/Transfer/order_budget_search_rest_api.transfer.xml
@@ -32,8 +32,9 @@
 
     <transfer name="RestOrderBudgetsAttributes">
         <property name="id" type="string"/>
-        <property name="budget" type="int"/>
         <property name="initialBudget" type="int" />
+        <property name="nextInitialBudget" type="int" />
+        <property name="budget" type="int"/>
     </transfer>
 
 
@@ -49,6 +50,7 @@
         <property name="uuid" type="string" />
         <property name="budget" type="int" />
         <property name="initialBudget" type="int" />
+        <property name="nextInitialBudget" type="int" />
         <property name="createdAt" type="string" />
         <property name="updatedAt" type="string" />
     </transfer>

--- a/bundles/order-budget-search-rest-api/src/FondOfOryx/Shared/OrderBudgetSearchRestApi/Transfer/order_budget_search_rest_api.transfer.xml
+++ b/bundles/order-budget-search-rest-api/src/FondOfOryx/Shared/OrderBudgetSearchRestApi/Transfer/order_budget_search_rest_api.transfer.xml
@@ -33,6 +33,7 @@
     <transfer name="RestOrderBudgetsAttributes">
         <property name="id" type="string"/>
         <property name="budget" type="int"/>
+        <property name="initialBudget" type="int" />
     </transfer>
 
 
@@ -47,6 +48,7 @@
         <property name="idOrderBudget" type="int" />
         <property name="uuid" type="string" />
         <property name="budget" type="int" />
+        <property name="initialBudget" type="int" />
         <property name="createdAt" type="string" />
         <property name="updatedAt" type="string" />
     </transfer>

--- a/bundles/order-budget/src/FondOfOryx/Shared/OrderBudget/Transfer/order_buget.transfer.xml
+++ b/bundles/order-budget/src/FondOfOryx/Shared/OrderBudget/Transfer/order_buget.transfer.xml
@@ -2,10 +2,10 @@
 <transfers xmlns="spryker:transfer-01"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="spryker:transfer-01 http://static.spryker.com/transfer-01.xsd">
-
     <transfer name="OrderBudget">
         <property name="idOrderBudget" type="int" />
         <property name="budget" type="int" />
+        <property name="initialBudget" type="int" />
         <property name="createdAt" type="string" />
         <property name="updatedAt" type="string" />
     </transfer>

--- a/bundles/order-budget/src/FondOfOryx/Shared/OrderBudget/Transfer/order_buget.transfer.xml
+++ b/bundles/order-budget/src/FondOfOryx/Shared/OrderBudget/Transfer/order_buget.transfer.xml
@@ -6,6 +6,7 @@
         <property name="idOrderBudget" type="int" />
         <property name="budget" type="int" />
         <property name="initialBudget" type="int" />
+        <property name="nextInitialBudget" type="int" />
         <property name="createdAt" type="string" />
         <property name="updatedAt" type="string" />
     </transfer>

--- a/bundles/order-budget/src/FondOfOryx/Zed/OrderBudget/Business/OrderBudgetBusinessFactory.php
+++ b/bundles/order-budget/src/FondOfOryx/Zed/OrderBudget/Business/OrderBudgetBusinessFactory.php
@@ -42,6 +42,7 @@ class OrderBudgetBusinessFactory extends AbstractBusinessFactory
             $this->createOrderBudgetHistoryMapper(),
             $this->getUtilDateTimeService(),
             $this->getEntityManager(),
+            $this->getConfig(),
         );
     }
 

--- a/bundles/order-budget/src/FondOfOryx/Zed/OrderBudget/Business/OrderBudgetBusinessFactory.php
+++ b/bundles/order-budget/src/FondOfOryx/Zed/OrderBudget/Business/OrderBudgetBusinessFactory.php
@@ -42,7 +42,6 @@ class OrderBudgetBusinessFactory extends AbstractBusinessFactory
             $this->createOrderBudgetHistoryMapper(),
             $this->getUtilDateTimeService(),
             $this->getEntityManager(),
-            $this->getConfig(),
         );
     }
 

--- a/bundles/order-budget/src/FondOfOryx/Zed/OrderBudget/Business/Resetter/OrderBudgetResetter.php
+++ b/bundles/order-budget/src/FondOfOryx/Zed/OrderBudget/Business/Resetter/OrderBudgetResetter.php
@@ -6,6 +6,7 @@ use DateTime;
 use FondOfOryx\Zed\OrderBudget\Business\Mapper\OrderBudgetHistoryMapperInterface;
 use FondOfOryx\Zed\OrderBudget\Business\Reader\OrderBudgetReaderInterface;
 use FondOfOryx\Zed\OrderBudget\Dependency\Service\OrderBudgetToUtilDateTimeServiceInterface;
+use FondOfOryx\Zed\OrderBudget\OrderBudgetConfig;
 use FondOfOryx\Zed\OrderBudget\Persistence\OrderBudgetEntityManagerInterface;
 use Spryker\Zed\Kernel\Persistence\EntityManager\TransactionTrait;
 
@@ -34,21 +35,29 @@ class OrderBudgetResetter implements OrderBudgetResetterInterface
     protected $entityManager;
 
     /**
+     * @var \FondOfOryx\Zed\OrderBudget\OrderBudgetConfig
+     */
+    protected $config;
+
+    /**
      * @param \FondOfOryx\Zed\OrderBudget\Business\Reader\OrderBudgetReaderInterface $orderBudgetReader
      * @param \FondOfOryx\Zed\OrderBudget\Business\Mapper\OrderBudgetHistoryMapperInterface $orderBudgetHistoryMapper
      * @param \FondOfOryx\Zed\OrderBudget\Dependency\Service\OrderBudgetToUtilDateTimeServiceInterface $utilDateTimeService
      * @param \FondOfOryx\Zed\OrderBudget\Persistence\OrderBudgetEntityManagerInterface $entityManager
+     * @param \FondOfOryx\Zed\OrderBudget\OrderBudgetConfig $config
      */
     public function __construct(
         OrderBudgetReaderInterface $orderBudgetReader,
         OrderBudgetHistoryMapperInterface $orderBudgetHistoryMapper,
         OrderBudgetToUtilDateTimeServiceInterface $utilDateTimeService,
-        OrderBudgetEntityManagerInterface $entityManager
+        OrderBudgetEntityManagerInterface $entityManager,
+        OrderBudgetConfig $config
     ) {
         $this->orderBudgetReader = $orderBudgetReader;
         $this->orderBudgetHistoryMapper = $orderBudgetHistoryMapper;
         $this->utilDateTimeService = $utilDateTimeService;
         $this->entityManager = $entityManager;
+        $this->config = $config;
     }
 
     /**
@@ -77,6 +86,10 @@ class OrderBudgetResetter implements OrderBudgetResetterInterface
                 ->setValidTo($now);
 
             $this->entityManager->createOrderBudgetHistory($orderBudgetHistoryTransfer);
+
+            if ($orderBudgetTransfer->getInitialBudget() === null) {
+                $orderBudgetTransfer->setInitialBudget($this->config->getInitialBudget());
+            }
 
             $orderBudgetTransfer->setBudget($orderBudgetTransfer->getInitialBudget());
 

--- a/bundles/order-budget/src/FondOfOryx/Zed/OrderBudget/Business/Resetter/OrderBudgetResetter.php
+++ b/bundles/order-budget/src/FondOfOryx/Zed/OrderBudget/Business/Resetter/OrderBudgetResetter.php
@@ -6,7 +6,6 @@ use DateTime;
 use FondOfOryx\Zed\OrderBudget\Business\Mapper\OrderBudgetHistoryMapperInterface;
 use FondOfOryx\Zed\OrderBudget\Business\Reader\OrderBudgetReaderInterface;
 use FondOfOryx\Zed\OrderBudget\Dependency\Service\OrderBudgetToUtilDateTimeServiceInterface;
-use FondOfOryx\Zed\OrderBudget\OrderBudgetConfig;
 use FondOfOryx\Zed\OrderBudget\Persistence\OrderBudgetEntityManagerInterface;
 use Spryker\Zed\Kernel\Persistence\EntityManager\TransactionTrait;
 
@@ -35,29 +34,21 @@ class OrderBudgetResetter implements OrderBudgetResetterInterface
     protected $entityManager;
 
     /**
-     * @var \FondOfOryx\Zed\OrderBudget\OrderBudgetConfig
-     */
-    protected $config;
-
-    /**
      * @param \FondOfOryx\Zed\OrderBudget\Business\Reader\OrderBudgetReaderInterface $orderBudgetReader
      * @param \FondOfOryx\Zed\OrderBudget\Business\Mapper\OrderBudgetHistoryMapperInterface $orderBudgetHistoryMapper
      * @param \FondOfOryx\Zed\OrderBudget\Dependency\Service\OrderBudgetToUtilDateTimeServiceInterface $utilDateTimeService
      * @param \FondOfOryx\Zed\OrderBudget\Persistence\OrderBudgetEntityManagerInterface $entityManager
-     * @param \FondOfOryx\Zed\OrderBudget\OrderBudgetConfig $config
      */
     public function __construct(
         OrderBudgetReaderInterface $orderBudgetReader,
         OrderBudgetHistoryMapperInterface $orderBudgetHistoryMapper,
         OrderBudgetToUtilDateTimeServiceInterface $utilDateTimeService,
-        OrderBudgetEntityManagerInterface $entityManager,
-        OrderBudgetConfig $config
+        OrderBudgetEntityManagerInterface $entityManager
     ) {
         $this->orderBudgetReader = $orderBudgetReader;
         $this->orderBudgetHistoryMapper = $orderBudgetHistoryMapper;
         $this->utilDateTimeService = $utilDateTimeService;
         $this->entityManager = $entityManager;
-        $this->config = $config;
     }
 
     /**
@@ -77,7 +68,6 @@ class OrderBudgetResetter implements OrderBudgetResetterInterface
      */
     protected function executeResetAllTransaction(): void
     {
-        $initialBudget = $this->config->getInitialBudget();
         $orderBudgetTransfers = $this->orderBudgetReader->getAll();
 
         foreach ($orderBudgetTransfers as $orderBudgetTransfer) {
@@ -88,7 +78,7 @@ class OrderBudgetResetter implements OrderBudgetResetterInterface
 
             $this->entityManager->createOrderBudgetHistory($orderBudgetHistoryTransfer);
 
-            $orderBudgetTransfer->setBudget($initialBudget);
+            $orderBudgetTransfer->setBudget($orderBudgetTransfer->getInitialBudget());
 
             $this->entityManager->updateOrderBudget($orderBudgetTransfer);
         }

--- a/bundles/order-budget/src/FondOfOryx/Zed/OrderBudget/Business/Resetter/OrderBudgetResetter.php
+++ b/bundles/order-budget/src/FondOfOryx/Zed/OrderBudget/Business/Resetter/OrderBudgetResetter.php
@@ -87,11 +87,14 @@ class OrderBudgetResetter implements OrderBudgetResetterInterface
 
             $this->entityManager->createOrderBudgetHistory($orderBudgetHistoryTransfer);
 
-            if ($orderBudgetTransfer->getInitialBudget() === null) {
-                $orderBudgetTransfer->setInitialBudget($this->config->getInitialBudget());
+            if ($orderBudgetTransfer->getNextInitialBudget() === null) {
+                $orderBudgetTransfer->setNextInitialBudget($this->config->getInitialBudget());
             }
 
-            $orderBudgetTransfer->setBudget($orderBudgetTransfer->getInitialBudget());
+            $nextInitialBudget = $orderBudgetTransfer->getNextInitialBudget();
+
+            $orderBudgetTransfer->setInitialBudget($nextInitialBudget)
+                ->setBudget($nextInitialBudget);
 
             $this->entityManager->updateOrderBudget($orderBudgetTransfer);
         }

--- a/bundles/order-budget/src/FondOfOryx/Zed/OrderBudget/Business/Writer/OrderBudgetWriter.php
+++ b/bundles/order-budget/src/FondOfOryx/Zed/OrderBudget/Business/Writer/OrderBudgetWriter.php
@@ -41,7 +41,9 @@ class OrderBudgetWriter implements OrderBudgetWriterInterface
             $budget = $this->config->getInitialBudget();
         }
 
-        $orderBudgetTransfer = (new OrderBudgetTransfer())->setBudget($budget);
+        $orderBudgetTransfer = (new OrderBudgetTransfer())
+            ->setInitialBudget($budget)
+            ->setBudget($budget);
 
         return $this->entityManager->createOrderBudget($orderBudgetTransfer);
     }

--- a/bundles/order-budget/src/FondOfOryx/Zed/OrderBudget/Business/Writer/OrderBudgetWriter.php
+++ b/bundles/order-budget/src/FondOfOryx/Zed/OrderBudget/Business/Writer/OrderBudgetWriter.php
@@ -42,6 +42,7 @@ class OrderBudgetWriter implements OrderBudgetWriterInterface
         }
 
         $orderBudgetTransfer = (new OrderBudgetTransfer())
+            ->setNextInitialBudget($budget)
             ->setInitialBudget($budget)
             ->setBudget($budget);
 

--- a/bundles/order-budget/src/FondOfOryx/Zed/OrderBudget/Persistence/OrderBudgetEntityManager.php
+++ b/bundles/order-budget/src/FondOfOryx/Zed/OrderBudget/Persistence/OrderBudgetEntityManager.php
@@ -45,7 +45,7 @@ class OrderBudgetEntityManager extends AbstractEntityManager implements OrderBud
             return;
         }
 
-        $entity->fromArray($orderBudgetTransfer->toArray(true));
+        $entity->fromArray($orderBudgetTransfer->modifiedToArray(true));
 
         $entity->save();
     }

--- a/bundles/order-budget/src/FondOfOryx/Zed/OrderBudget/Persistence/Propel/Schema/foo_order_budget.schema.xml
+++ b/bundles/order-budget/src/FondOfOryx/Zed/OrderBudget/Persistence/Propel/Schema/foo_order_budget.schema.xml
@@ -6,6 +6,7 @@
 
     <table name="foo_order_budget">
         <column name="id_order_budget" type="INTEGER" required="true" autoIncrement="true" primaryKey="true"/>
+        <column name="initial_budget" type="INTEGER" required="true"/>
         <column name="budget" type="INTEGER" required="true"/>
 
         <id-method-parameter value="foo_order_budget_pk_seq"/>
@@ -16,6 +17,8 @@
     <table name="foo_order_budget_history">
         <column name="id_order_budget_history" type="INTEGER" required="true" autoIncrement="true" primaryKey="true"/>
         <column name="fk_order_budget" type="INTEGER" required="true"/>
+        <column name="initial_budget" type="INTEGER" required="true"/>
+        <column name="budget" type="INTEGER" required="true"/>
         <column name="valid_from" type="DATE" required="true"/>
         <column name="valid_to" type="DATE" required="true"/>
 

--- a/bundles/order-budget/src/FondOfOryx/Zed/OrderBudget/Persistence/Propel/Schema/foo_order_budget.schema.xml
+++ b/bundles/order-budget/src/FondOfOryx/Zed/OrderBudget/Persistence/Propel/Schema/foo_order_budget.schema.xml
@@ -6,7 +6,7 @@
 
     <table name="foo_order_budget">
         <column name="id_order_budget" type="INTEGER" required="true" autoIncrement="true" primaryKey="true"/>
-        <column name="initial_budget" type="INTEGER" required="true"/>
+        <column name="initial_budget" type="INTEGER" required="false"/>
         <column name="budget" type="INTEGER" required="true"/>
 
         <id-method-parameter value="foo_order_budget_pk_seq"/>

--- a/bundles/order-budget/src/FondOfOryx/Zed/OrderBudget/Persistence/Propel/Schema/foo_order_budget.schema.xml
+++ b/bundles/order-budget/src/FondOfOryx/Zed/OrderBudget/Persistence/Propel/Schema/foo_order_budget.schema.xml
@@ -7,6 +7,7 @@
     <table name="foo_order_budget">
         <column name="id_order_budget" type="INTEGER" required="true" autoIncrement="true" primaryKey="true"/>
         <column name="initial_budget" type="INTEGER" required="false"/>
+        <column name="next_initial_budget" type="INTEGER" required="false"/>
         <column name="budget" type="INTEGER" required="true"/>
 
         <id-method-parameter value="foo_order_budget_pk_seq"/>
@@ -18,6 +19,7 @@
         <column name="id_order_budget_history" type="INTEGER" required="true" autoIncrement="true" primaryKey="true"/>
         <column name="fk_order_budget" type="INTEGER" required="true"/>
         <column name="initial_budget" type="INTEGER" required="false"/>
+        <column name="next_initial_budget" type="INTEGER" required="false"/>
         <column name="budget" type="INTEGER" required="true"/>
         <column name="valid_from" type="DATE" required="true"/>
         <column name="valid_to" type="DATE" required="true"/>

--- a/bundles/order-budget/src/FondOfOryx/Zed/OrderBudget/Persistence/Propel/Schema/foo_order_budget.schema.xml
+++ b/bundles/order-budget/src/FondOfOryx/Zed/OrderBudget/Persistence/Propel/Schema/foo_order_budget.schema.xml
@@ -17,7 +17,7 @@
     <table name="foo_order_budget_history">
         <column name="id_order_budget_history" type="INTEGER" required="true" autoIncrement="true" primaryKey="true"/>
         <column name="fk_order_budget" type="INTEGER" required="true"/>
-        <column name="initial_budget" type="INTEGER" required="true"/>
+        <column name="initial_budget" type="INTEGER" required="false"/>
         <column name="budget" type="INTEGER" required="true"/>
         <column name="valid_from" type="DATE" required="true"/>
         <column name="valid_to" type="DATE" required="true"/>

--- a/bundles/order-budget/tests/FondOfOryx/Zed/OrderBudget/Business/Resetter/OrderBudgetResetterTest.php
+++ b/bundles/order-budget/tests/FondOfOryx/Zed/OrderBudget/Business/Resetter/OrderBudgetResetterTest.php
@@ -192,12 +192,20 @@ class OrderBudgetResetterTest extends Unit
             ->with($this->orderBudgetHistoryTransferMocks[0]);
 
         $this->orderBudgetTransferMocks[0]->expects(static::atLeastOnce())
-            ->method('getInitialBudget')
-            ->willReturnOnConsecutiveCalls(null, OrderBudgetConstants::INITIAL_BUDGET_DEFAULT);
+            ->method('getNextInitialBudget')
+            ->willReturnOnConsecutiveCalls(
+                null,
+                OrderBudgetConstants::INITIAL_BUDGET_DEFAULT,
+            );
 
         $this->configMock->expects(static::atLeastOnce())
             ->method('getInitialBudget')
             ->willReturn(OrderBudgetConstants::INITIAL_BUDGET_DEFAULT);
+
+        $this->orderBudgetTransferMocks[0]->expects(static::atLeastOnce())
+            ->method('setNextInitialBudget')
+            ->with(OrderBudgetConstants::INITIAL_BUDGET_DEFAULT)
+            ->willReturn($this->orderBudgetTransferMocks[0]);
 
         $this->orderBudgetTransferMocks[0]->expects(static::atLeastOnce())
             ->method('setInitialBudget')

--- a/bundles/order-budget/tests/FondOfOryx/Zed/OrderBudget/Business/Resetter/OrderBudgetResetterTest.php
+++ b/bundles/order-budget/tests/FondOfOryx/Zed/OrderBudget/Business/Resetter/OrderBudgetResetterTest.php
@@ -8,6 +8,7 @@ use FondOfOryx\Shared\OrderBudget\OrderBudgetConstants;
 use FondOfOryx\Zed\OrderBudget\Business\Mapper\OrderBudgetHistoryMapperInterface;
 use FondOfOryx\Zed\OrderBudget\Business\Reader\OrderBudgetReaderInterface;
 use FondOfOryx\Zed\OrderBudget\Dependency\Service\OrderBudgetToUtilDateTimeServiceInterface;
+use FondOfOryx\Zed\OrderBudget\OrderBudgetConfig;
 use FondOfOryx\Zed\OrderBudget\Persistence\OrderBudgetEntityManagerInterface;
 use Generated\Shared\Transfer\OrderBudgetHistoryTransfer;
 use Generated\Shared\Transfer\OrderBudgetTransfer;
@@ -34,6 +35,11 @@ class OrderBudgetResetterTest extends Unit
      * @var \FondOfOryx\Zed\OrderBudget\Persistence\OrderBudgetEntityManagerInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $entityManagerMock;
+
+    /**
+     * @var \FondOfOryx\Zed\OrderBudget\OrderBudgetConfig|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $configMock;
 
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\Kernel\Persistence\EntityManager\TransactionHandlerInterface
@@ -78,6 +84,10 @@ class OrderBudgetResetterTest extends Unit
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->configMock = $this->getMockBuilder(OrderBudgetConfig::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $this->transactionHandlerMock = $this->getMockBuilder(TransactionHandlerInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -99,6 +109,7 @@ class OrderBudgetResetterTest extends Unit
             $this->orderBudgetHistoryMapperMock,
             $this->utilDateTimeServiceMock,
             $this->entityManagerMock,
+            $this->configMock,
             $this->transactionHandlerMock
         ) extends OrderBudgetResetter {
             /**
@@ -111,6 +122,7 @@ class OrderBudgetResetterTest extends Unit
              * @param \FondOfOryx\Zed\OrderBudget\Business\Mapper\OrderBudgetHistoryMapperInterface $orderBudgetHistoryMapper
              * @param \FondOfOryx\Zed\OrderBudget\Dependency\Service\OrderBudgetToUtilDateTimeServiceInterface $utilDateTimeService
              * @param \FondOfOryx\Zed\OrderBudget\Persistence\OrderBudgetEntityManagerInterface $entityManager
+             * @param \FondOfOryx\Zed\OrderBudget\OrderBudgetConfig $config
              * @param \Spryker\Zed\Kernel\Persistence\EntityManager\TransactionHandlerInterface $transactionHandler
              */
             public function __construct(
@@ -118,6 +130,7 @@ class OrderBudgetResetterTest extends Unit
                 OrderBudgetHistoryMapperInterface $orderBudgetHistoryMapper,
                 OrderBudgetToUtilDateTimeServiceInterface $utilDateTimeService,
                 OrderBudgetEntityManagerInterface $entityManager,
+                OrderBudgetConfig $config,
                 TransactionHandlerInterface $transactionHandler
             ) {
                 parent::__construct(
@@ -125,6 +138,7 @@ class OrderBudgetResetterTest extends Unit
                     $orderBudgetHistoryMapper,
                     $utilDateTimeService,
                     $entityManager,
+                    $config,
                 );
 
                 $this->transactionHandler = $transactionHandler;
@@ -179,7 +193,16 @@ class OrderBudgetResetterTest extends Unit
 
         $this->orderBudgetTransferMocks[0]->expects(static::atLeastOnce())
             ->method('getInitialBudget')
+            ->willReturnOnConsecutiveCalls(null, OrderBudgetConstants::INITIAL_BUDGET_DEFAULT);
+
+        $this->configMock->expects(static::atLeastOnce())
+            ->method('getInitialBudget')
             ->willReturn(OrderBudgetConstants::INITIAL_BUDGET_DEFAULT);
+
+        $this->orderBudgetTransferMocks[0]->expects(static::atLeastOnce())
+            ->method('setInitialBudget')
+            ->with(OrderBudgetConstants::INITIAL_BUDGET_DEFAULT)
+            ->willReturn($this->orderBudgetTransferMocks[0]);
 
         $this->orderBudgetTransferMocks[0]->expects(static::atLeastOnce())
             ->method('setBudget')

--- a/bundles/order-budget/tests/FondOfOryx/Zed/OrderBudget/Business/Resetter/OrderBudgetResetterTest.php
+++ b/bundles/order-budget/tests/FondOfOryx/Zed/OrderBudget/Business/Resetter/OrderBudgetResetterTest.php
@@ -8,7 +8,6 @@ use FondOfOryx\Shared\OrderBudget\OrderBudgetConstants;
 use FondOfOryx\Zed\OrderBudget\Business\Mapper\OrderBudgetHistoryMapperInterface;
 use FondOfOryx\Zed\OrderBudget\Business\Reader\OrderBudgetReaderInterface;
 use FondOfOryx\Zed\OrderBudget\Dependency\Service\OrderBudgetToUtilDateTimeServiceInterface;
-use FondOfOryx\Zed\OrderBudget\OrderBudgetConfig;
 use FondOfOryx\Zed\OrderBudget\Persistence\OrderBudgetEntityManagerInterface;
 use Generated\Shared\Transfer\OrderBudgetHistoryTransfer;
 use Generated\Shared\Transfer\OrderBudgetTransfer;
@@ -35,11 +34,6 @@ class OrderBudgetResetterTest extends Unit
      * @var \FondOfOryx\Zed\OrderBudget\Persistence\OrderBudgetEntityManagerInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $entityManagerMock;
-
-    /**
-     * @var \FondOfOryx\Zed\OrderBudget\OrderBudgetConfig|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected $configMock;
 
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\Kernel\Persistence\EntityManager\TransactionHandlerInterface
@@ -84,10 +78,6 @@ class OrderBudgetResetterTest extends Unit
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->configMock = $this->getMockBuilder(OrderBudgetConfig::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
         $this->transactionHandlerMock = $this->getMockBuilder(TransactionHandlerInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -109,7 +99,6 @@ class OrderBudgetResetterTest extends Unit
             $this->orderBudgetHistoryMapperMock,
             $this->utilDateTimeServiceMock,
             $this->entityManagerMock,
-            $this->configMock,
             $this->transactionHandlerMock
         ) extends OrderBudgetResetter {
             /**
@@ -122,7 +111,6 @@ class OrderBudgetResetterTest extends Unit
              * @param \FondOfOryx\Zed\OrderBudget\Business\Mapper\OrderBudgetHistoryMapperInterface $orderBudgetHistoryMapper
              * @param \FondOfOryx\Zed\OrderBudget\Dependency\Service\OrderBudgetToUtilDateTimeServiceInterface $utilDateTimeService
              * @param \FondOfOryx\Zed\OrderBudget\Persistence\OrderBudgetEntityManagerInterface $entityManager
-             * @param \FondOfOryx\Zed\OrderBudget\OrderBudgetConfig $config
              * @param \Spryker\Zed\Kernel\Persistence\EntityManager\TransactionHandlerInterface $transactionHandler
              */
             public function __construct(
@@ -130,7 +118,6 @@ class OrderBudgetResetterTest extends Unit
                 OrderBudgetHistoryMapperInterface $orderBudgetHistoryMapper,
                 OrderBudgetToUtilDateTimeServiceInterface $utilDateTimeService,
                 OrderBudgetEntityManagerInterface $entityManager,
-                OrderBudgetConfig $config,
                 TransactionHandlerInterface $transactionHandler
             ) {
                 parent::__construct(
@@ -138,7 +125,6 @@ class OrderBudgetResetterTest extends Unit
                     $orderBudgetHistoryMapper,
                     $utilDateTimeService,
                     $entityManager,
-                    $config,
                 );
 
                 $this->transactionHandler = $transactionHandler;
@@ -169,10 +155,6 @@ class OrderBudgetResetterTest extends Unit
                 },
             );
 
-        $this->configMock->expects(static::atLeastOnce())
-            ->method('getInitialBudget')
-            ->willReturn(OrderBudgetConstants::INITIAL_BUDGET_DEFAULT);
-
         $this->orderBudgetReaderMock->expects(static::atLeastOnce())
             ->method('getAll')
             ->willReturn($this->orderBudgetTransferMocks);
@@ -194,6 +176,10 @@ class OrderBudgetResetterTest extends Unit
         $this->entityManagerMock->expects(static::atLeastOnce())
             ->method('createOrderBudgetHistory')
             ->with($this->orderBudgetHistoryTransferMocks[0]);
+
+        $this->orderBudgetTransferMocks[0]->expects(static::atLeastOnce())
+            ->method('getInitialBudget')
+            ->willReturn(OrderBudgetConstants::INITIAL_BUDGET_DEFAULT);
 
         $this->orderBudgetTransferMocks[0]->expects(static::atLeastOnce())
             ->method('setBudget')

--- a/dandelion.json
+++ b/dandelion.json
@@ -721,11 +721,11 @@
     },
     "order-budget": {
       "path": "bundles/order-budget/",
-      "version": "2.1.0"
+      "version": "2.2.0"
     },
     "order-budget-search-rest-api": {
       "path": "bundles/order-budget-search-rest-api/",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     "order-budget-search-rest-api-extension": {
       "path": "bundles/order-budget-search-rest-api-extension/",


### PR DESCRIPTION
- add `initial_budget` as column to table `foo_order_budget` and  `foo_order_budget_history`
- add response attribute property `initialBudget` to glue endpoint `order-budget-search`
- increase minor versions for effected bundles `fond-of-oryx/order-budget` and `fond-of-oryx/order-budget-search-rest-api`
- prepare unit tests
- ...